### PR TITLE
CMake: link gtracers library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,8 +60,8 @@ else()
   message(WARNING "C compiler with ID ${CMAKE_C_COMPILER_ID} will be used with CMake default options")
 endif()
 
-
-add_compile_definitions(_USE_GENERIC_TRACER _USE_MOM6_DIAG)
+# See https://github.com/ACCESS-NRI/GFDL-generic-tracers/issues/29
+add_compile_definitions(_USE_GENERIC_TRACER) # _USE_MOM6_DIAG)
 
 if (MOM6_ACCESS3)
   add_compile_definitions(CESMCOUPLED)
@@ -78,6 +78,7 @@ set(CMAKE_INSTALL_MODULEDIR ${CMAKE_INSTALL_INCLUDEDIR}
 #]==============================================================================]
 
 find_package(fms COMPONENTS R8 REQUIRED)
+find_package(GFDLGTracers REQUIRED)
 
 if(NOT TARGET NetCDF::NetCDF_Fortran OR NOT TARGET NetCDF::NetCDF_C) #fms provides NETCDF inteface
   message(FATAL_ERROR "NetCDF interface missing from FMS package")
@@ -124,7 +125,7 @@ target_include_directories(mom6lib PRIVATE ${MOM_MEMORY_DIR})
 target_compile_options(mom6lib PRIVATE "$<$<COMPILE_LANGUAGE:Fortran>:${fortran_compile_flags}>")
 
 # link libraries
-target_link_libraries(mom6lib PRIVATE FMS::fms_r8)
+target_link_libraries(mom6lib PRIVATE FMS::fms_r8 GFDLGTracers::gtracers)
 
 if(MOM6_ACCESS3)
   target_link_libraries(mom6lib
@@ -420,9 +421,6 @@ target_sources(mom6lib PRIVATE
 
   ${CONFIG_SRC}/external/stochastic_physics/get_stochy_pattern.F90
   ${CONFIG_SRC}/external/stochastic_physics/stochastic_physics.F90
-
-  ${CONFIG_SRC}/external/GFDL_ocean_BGC/generic_tracer_utils.F90
-  ${CONFIG_SRC}/external/GFDL_ocean_BGC/generic_tracer.F90
 
   ${CONFIG_SRC}/infra/FMS2/MOM_coms_infra.F90
   ${CONFIG_SRC}/infra/FMS2/MOM_constants.F90

--- a/cmake/Mom6libConfig.cmake.in
+++ b/cmake/Mom6libConfig.cmake.in
@@ -12,7 +12,7 @@ include(CMakeFindDependencyMacro)
 set(_required_components ${Mom6lib_FIND_COMPONENTS})
 
 find_dependency(fms COMPONENTS R8 REQUIRED)
-find_package(GFDLGTracers REQUIRED)
+find_dependency(GFDLGTracers REQUIRED)
 find_dependency(NetCDF REQUIRED Fortran)
 if (NOT NetCDF_PARALLEL)
     message(FATAL_ERROR "NetCDF does not have parallel I/O support!")

--- a/cmake/Mom6libConfig.cmake.in
+++ b/cmake/Mom6libConfig.cmake.in
@@ -12,6 +12,7 @@ include(CMakeFindDependencyMacro)
 set(_required_components ${Mom6lib_FIND_COMPONENTS})
 
 find_dependency(fms COMPONENTS R8 REQUIRED)
+find_package(GFDLGTracers REQUIRED)
 find_dependency(NetCDF REQUIRED Fortran)
 if (NOT NetCDF_PARALLEL)
     message(FATAL_ERROR "NetCDF does not have parallel I/O support!")


### PR DESCRIPTION
This PR modifies the CMake build to link `GFDLGTracers::gtracers` with the `mom6lib` target.

The `_USE_MOM6_DIAG` directive is also removed - see https://github.com/ACCESS-NRI/GFDL-generic-tracers/issues/29 for justification.

Closes https://github.com/ACCESS-NRI/access-om3-configs/issues/557

Relevant:
- https://github.com/ACCESS-NRI/spack-packages/pull/241