### PR TITLE
Add salt flux adjustment (sflx_adj) to `fluxes%salt_flux`

### DIFF
--- a/config_src/drivers/FMS_cap/MOM_surface_forcing_gfdl.F90
+++ b/config_src/drivers/FMS_cap/MOM_surface_forcing_gfdl.F90
@@ -1192,6 +1192,7 @@ subroutine apply_flux_adjustments(G, US, CS, Time, fluxes)
                      scale=US%kg_m2s_to_RZ_T)
 
   if (overrode_h) then ; do j=jsc,jec ; do i=isc,iec
+    fluxes%salt_flux(i,j) = fluxes%salt_flux(i,j) + temp_at_h(i,j) * G%mask2dT(i,j)
     fluxes%salt_flux_added(i,j) = fluxes%salt_flux_added(i,j) + temp_at_h(i,j) * G%mask2dT(i,j)
   enddo ; enddo ; endif
   ! Not needed? ! if (overrode_h) call pass_var(fluxes%salt_flux_added, G%Domain)

--- a/config_src/drivers/STALE_mct_cap/mom_surface_forcing_mct.F90
+++ b/config_src/drivers/STALE_mct_cap/mom_surface_forcing_mct.F90
@@ -911,6 +911,8 @@ subroutine apply_flux_adjustments(G, US, CS, Time, fluxes)
   call data_override('OCN', 'sflx_adj', temp_at_h(isc:iec,jsc:jec), Time, override=overrode_h)
 
   if (overrode_h) then ; do j=jsc,jec ; do i=isc,iec
+    fluxes%salt_flux(i,j) = fluxes%salt_flux(i,j) + &
+            US%kg_m2s_to_RZ_T * temp_at_h(i,j)* G%mask2dT(i,j)
     fluxes%salt_flux_added(i,j) = fluxes%salt_flux_added(i,j) + &
             US%kg_m2s_to_RZ_T * temp_at_h(i,j)* G%mask2dT(i,j)
   enddo ; enddo ; endif

--- a/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
+++ b/config_src/drivers/nuopc_cap/mom_surface_forcing_nuopc.F90
@@ -988,6 +988,8 @@ subroutine apply_flux_adjustments(G, US, CS, Time, fluxes)
   call data_override('OCN', 'sflx_adj', temp_at_h(isc:iec,jsc:jec), Time, override=overrode_h)
 
   if (overrode_h) then ; do j=jsc,jec ; do i=isc,iec
+    fluxes%salt_flux(i,j) = fluxes%salt_flux(i,j) + &
+        US%kg_m2s_to_RZ_T * temp_at_h(i,j)* G%mask2dT(i,j)
     fluxes%salt_flux_added(i,j) = fluxes%salt_flux_added(i,j) + &
         US%kg_m2s_to_RZ_T * temp_at_h(i,j)* G%mask2dT(i,j)
   enddo ; enddo ; endif


### PR DESCRIPTION
This PR adds any applied salt flux adjustment to the total surface salt flux. The same fix is made to the NUOPC, FMS and MCT drivers.

Closes #17