### PR TITLE
Fix indexing i/j typo bug when `HMIX_UV_SFC_PROP`>0

### DIFF
--- a/src/core/MOM.F90
+++ b/src/core/MOM.F90
@@ -4137,7 +4137,7 @@ subroutine extract_surface_state(CS, sfc_state_in)
       depth_ml = CS%Hmix_UV
       if (CS%answer_date < 20190101) depth_ml = GV%H_to_Z*CS%Hmix_UV
       !$OMP parallel do default(shared) private(depth,dh,hv)
-      do J=js-1,ie
+      do J=js-1,je
         do i=is,ie
           depth(i) = 0.0
           sfc_state%v(i,J) = 0.0


### PR DESCRIPTION
There was a typo with the calculation of mean velocities in the uppermost depth_ml fluid. It was written `J=js-1,ie` instead of `J=js-1,je` and therefore crashed with an indexing error when used. This section of the code only gets used when `(CS%Hmix_UV>0.)` i.e. when runtime parameter `HMIX_UV_SFC_PROP` > 0. The runtime parameter default is zero. I have not added a runtime parameter fixing the bug optionally because without the bugfix it would crash if using this parameter. However, it should not change answers in simulations that use the default `HMIX_UV_SFC_PROP`.

resolves https://github.com/ACCESS-NRI/MOM6/issues/12