### PR TITLE
Test out having multiple upstreams of spack in self-hosted mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       allow-ssh-into-spack-install: false  # If true, PR author must ssh into instance to complete job
       spack-manifest-data-path: .github/build-ci/data/standard.json
       spack-packages-ref: api-v2
-      # FIXME: This tests having multiple upstreams for different versions of spack
+      # FIXME: This tests having multiple upstreams for different versions of spack!
       spack-config-ref: build-ci-247-multi-upstream
       spack-ref: releases/v1.0
       container-image-version: :rocky-v1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,13 @@ jobs:
       max-parallel: 5
       matrix:
         file: ${{ fromJson(needs.pre-ci.outputs.matrix) }}
-    uses: access-nri/build-ci/.github/workflows/ci.yml@v2
+    uses: access-nri/build-ci/.github/workflows/ci.yml@247-multi-upstream
     with:
       spack-manifest-path: ${{ matrix.file }}
       allow-ssh-into-spack-install: false  # If true, PR author must ssh into instance to complete job
       spack-manifest-data-path: .github/build-ci/data/standard.json
       spack-packages-ref: api-v2
-      # FIXME: This is a workaround for having a spack 1.0 runner using a spack 0.22 upstream, and should be removed once we transition to a 1.0 upstream
-      spack-config-ref: 74-perl-buildable
+      # FIXME: This tests having multiple upstreams for different versions of spack
+      spack-config-ref: build-ci-247-multi-upstream
       spack-ref: releases/v1.0
-      container-image-version: :rocky-v1.0-2025.09.002
+      container-image-version: :rocky-v1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,4 @@ jobs:
       # FIXME: This tests having multiple upstreams for different versions of spack!
       spack-config-ref: build-ci-247-multi-upstream
       spack-ref: releases/v1.0
-      container-image-version: :rocky-v1.0
+      container-image-version: :rocky-v1.0-2025.09.003

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       allow-ssh-into-spack-install: false  # If true, PR author must ssh into instance to complete job
       spack-manifest-data-path: .github/build-ci/data/standard.json
       spack-packages-ref: api-v2
-      # FIXME: This tests having multiple upstreams for different versions of spack! Blahblah
+      # FIXME: This tests having multiple upstreams for different versions of spack! Blahblablah
       spack-config-ref: 74-perl-buildable
       spack-ref: releases/v1.0
       container-image-version: :rocky-v1.0-2025.09.003

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       allow-ssh-into-spack-install: false  # If true, PR author must ssh into instance to complete job
       spack-manifest-data-path: .github/build-ci/data/standard.json
       spack-packages-ref: api-v2
-      # FIXME: This tests having multiple upstreams for different versions of spack! Blah
+      # FIXME: This tests having multiple upstreams for different versions of spack! Blahblah
       spack-config-ref: 74-perl-buildable
       spack-ref: releases/v1.0
       container-image-version: :rocky-v1.0-2025.09.003

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       allow-ssh-into-spack-install: false  # If true, PR author must ssh into instance to complete job
       spack-manifest-data-path: .github/build-ci/data/standard.json
       spack-packages-ref: api-v2
-      # FIXME: This tests having multiple upstreams for different versions of spack! Blahblablah
+      # FIXME: This tests having multiple upstreams for different versions of spack!
       spack-config-ref: 74-perl-buildable
       spack-ref: releases/v1.0
-      container-image-version: :rocky-v1.0-2025.09.003
+      container-image-version: :rocky-v1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       allow-ssh-into-spack-install: false  # If true, PR author must ssh into instance to complete job
       spack-manifest-data-path: .github/build-ci/data/standard.json
       spack-packages-ref: api-v2
-      # FIXME: This tests having multiple upstreams for different versions of spack!
+      # FIXME: This tests having multiple upstreams for different versions of spack! Blah
       spack-config-ref: 74-perl-buildable
       spack-ref: releases/v1.0
       container-image-version: :rocky-v1.0-2025.09.003

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,6 @@ jobs:
       spack-manifest-data-path: .github/build-ci/data/standard.json
       spack-packages-ref: api-v2
       # FIXME: This tests having multiple upstreams for different versions of spack!
-      spack-config-ref: build-ci-247-multi-upstream
+      spack-config-ref: 74-perl-buildable
       spack-ref: releases/v1.0
       container-image-version: :rocky-v1.0-2025.09.003


### PR DESCRIPTION
Testing out having multiple upstreams at once (with only one being linked to spack, corresponding to the runner spack version). 
