### PR TITLE
`build-ci v3`: Update Infra For `spack v1`

### DIFF
--- a/.github/build-ci/data/standard.json
+++ b/.github/build-ci/data/standard.json
@@ -1,4 +1,4 @@
 {
-  "oneapi_compiler": "oneapi@2025.2.0",
+  "oneapi_compiler_version": "2025.2.0",
   "target": "x86_64"
 }

--- a/.github/build-ci/manifests/oneapi_access-om3_asymm.spack.yaml.j2
+++ b/.github/build-ci/manifests/oneapi_access-om3_asymm.spack.yaml.j2
@@ -13,10 +13,15 @@ spack:
       - '@git.{{ ref }} +asymmetric_mem'
     gcc-runtime:
       require:
-      - '%gcc target={{ target }}'
+      - '%access_gcc'
+      - 'target={{ target }}'
+    intel-oneapi-compilers:
+      require:
+      - '@{{ oneapi_compiler_version }}'
     all:
       require:
-      - '%{{ oneapi_compiler }} target={{ target }}'
+      - '%access_oneapi'
+      - 'target={{ target }}'
   concretizer:
     unify: false
   view: false

--- a/.github/build-ci/manifests/oneapi_access-om3_no-asymm.spack.yaml.j2
+++ b/.github/build-ci/manifests/oneapi_access-om3_no-asymm.spack.yaml.j2
@@ -13,10 +13,15 @@ spack:
       - '@git.{{ ref }} ~asymmetric_mem'
     gcc-runtime:
       require:
-      - '%gcc target={{ target }}'
+      - '%access_gcc'
+      - 'target={{ target }}'
+    intel-oneapi-compilers:
+      require:
+      - '@{{ oneapi_compiler_version }}'
     all:
       require:
-      - '%{{ oneapi_compiler }} target={{ target }}'
+      - '%access_oneapi'
+      - 'target={{ target }}'
   concretizer:
     unify: false
   view: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
       # builtin-spack-packages-ref: main
       # access-spack-packages-ref: api-v2
       # spack-config-ref: main
-      # spack-ref: releases/v1.0
+      # spack-ref: releases/v1.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       spack-manifest-path: ${{ matrix.file }}
       allow-ssh-into-spack-install: false  # If true, PR author must ssh into instance to complete job
       spack-manifest-data-path: .github/build-ci/data/standard.json
-      # builtin-spack-packages-ref: main
+      # builtin-spack-packages-ref: develop
       # access-spack-packages-ref: api-v2
       # spack-config-ref: main
       # spack-ref: releases/v1.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,12 @@ jobs:
       max-parallel: 5
       matrix:
         file: ${{ fromJson(needs.pre-ci.outputs.matrix) }}
-    uses: access-nri/build-ci/.github/workflows/ci.yml@v2
+    uses: access-nri/build-ci/.github/workflows/ci.yml@v3
     with:
       spack-manifest-path: ${{ matrix.file }}
       allow-ssh-into-spack-install: false  # If true, PR author must ssh into instance to complete job
       spack-manifest-data-path: .github/build-ci/data/standard.json
-      spack-packages-ref: api-v2
-      # FIXME: This is a workaround for having a spack 1.0 runner using a spack 0.22 upstream, and should be removed once we transition to a 1.0 upstream
-      spack-config-ref: 74-perl-buildable
-      spack-ref: releases/v1.0
-      container-image-version: :rocky-v1.0-2025.09.002
+      # builtin-spack-packages-ref: main
+      # access-spack-packages-ref: api-v2
+      # spack-config-ref: main
+      # spack-ref: releases/v1.0


### PR DESCRIPTION
References issue ACCESS-NRI/build-ci#231 and PR ACCESS-NRI/build-ci#253
References project https://github.com/orgs/ACCESS-NRI/projects/37

> [!IMPORTANT]
> This PR is a major update to the infrastructure. See below for the prerequisites for this repository to be able to merge this PR.

> [!IMPORTANT]
> This major version change marks the end of major infrastructure updates for CI using `spack < 1.0`. They will still get bug fixes and non-breaking features if required.
> If you want to deploy to instances of `spack < 1.0`, you must use `build-ci v2`.
> If you want to deploy to instances of `spack >= 1.0`, you must use `build-ci v3`.

## Background

We are looking to transition `build-ci` to `v3`! This is due to a migration to `spack v1.X`, from `v0.X`, which offers many bug fixes, features, and optimisations.

One of these changes is the splitting of spacks core codebase from the builtin spack-packages repository, which means that we have another lever to tweak for our builds: the version of `spack`, `spack-config`, our `spack-packages` and the (new!) builtin `spack-packages`.

Since we want to leave open the possibility of forking the builtin `spack-packages`, we have also decided to rename `ACCESS-NRI/spack-packages` to `ACCESS-NRI/access-spack-packages`. See ACCESS-NRI/access-spack-packages#295 for more info.

Therefore this is a major version update, as there are the following changes to the inputs (and analogous changes to the workflow outputs):

* Deleted the optional `spack-packages-ref` input, which defaulted to `main` (in future, `api-v1`).
* Added the optional `access-spack-packages-ref` input, which defaults to the `api-v2` branch.
* Added the optional `builtin-spack-packages-ref` input, which defaults to the `main` branch.

This means that:

* If you want to use `container-image-version: :rocky-0.22-*`, or `spack-ref` < `releases/1.0`, you must stay on `v2` due to the input changes.
* If you want to use `container-image-version: :rocky-1.*-*`, or `spack-ref` >= `releases/1.0`, you must migrate to `v3` due to the input changes.

It is possible to test across these versions of `spack` if required, via a mix of workflow versions. Ask @CodeGat if you need this functionality.

## Features

The main new features include:

* **Proper Spack v1 Support**: Users now can tweak both the builtin `spack-packages` repository, as well as our own `access-spack-packages` repository. All of the bugfixes, features and optimisations added since `0.22` are available to us for future inclusion into `build-ci`.

## Prerequisites for Merging

- [x] Update `build-ci` entrypoints to `v3` (this PR!)
- [x] Determine if a specific `builtin-spack-packages-ref` is required
- [x] Determine if the added `access-spack-packages-ref` is appropriate
- [x] Validate if maintainers want to move to `spack v1` over `spack v0.22`
