### PR TITLE
Build CI: Add mom6_solo variant to manifests

### DIFF
--- a/.github/build-ci/manifests/oneapi_access-om3_symm.spack.yaml.j2
+++ b/.github/build-ci/manifests/oneapi_access-om3_symm.spack.yaml.j2
@@ -10,7 +10,7 @@ spack:
       - 'configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3'
     access-mom6:
       require:
-      - '@git.{{ ref }}=stable +asymmetric_mem +mom6_solo'
+      - '@git.{{ ref }}=stable ~asymmetric_mem +mom6_solo'
     gcc-runtime:
       require:
       - '%access_gcc'

--- a/.github/build-ci/manifests/oneapi_mom6_access3.spack.yaml.j2
+++ b/.github/build-ci/manifests/oneapi_mom6_access3.spack.yaml.j2
@@ -1,16 +1,10 @@
 spack:
   specs:
-  - 'access-om3@latest ^openmpi'
+  - 'access-mom6@git.{{ ref }}=stable +access3 ~mom6_solo ^openmpi'
   packages:
     cmake:
       require:
       - '@3.31.6'
-    access3:
-      require:
-      - 'configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3'
-    access-mom6:
-      require:
-      - '@git.{{ ref }}=stable +asymmetric_mem +mom6_solo'
     gcc-runtime:
       require:
       - '%access_gcc'

--- a/.github/build-ci/manifests/oneapi_mom6_solo.spack.yaml.j2
+++ b/.github/build-ci/manifests/oneapi_mom6_solo.spack.yaml.j2
@@ -1,16 +1,10 @@
 spack:
   specs:
-  - 'access-om3@latest ^openmpi'
+  - 'access-mom6@git.{{ ref }}=stable ~access3 +mom6_solo ^openmpi'
   packages:
     cmake:
       require:
       - '@3.31.6'
-    access3:
-      require:
-      - 'configurations=MOM6,MOM6-CICE6,MOM6-CICE6-WW3'
-    access-mom6:
-      require:
-      - '@git.{{ ref }} ~asymmetric_mem'
     gcc-runtime:
       require:
       - '%access_gcc'


### PR DESCRIPTION
Companion to #36 to add new `mom6_solo` variant to build-ci manifests.

Done as two separate PRs to allow separate signed commits without a merge commit.