### PR TITLE
Fix character buffer overflow in neutral diffusion #1702

### DIFF
--- a/src/tracer/MOM_neutral_diffusion.F90
+++ b/src/tracer/MOM_neutral_diffusion.F90
@@ -1581,7 +1581,7 @@ real function interpolate_for_nondim_position(dRhoNeg, Pneg, dRhoPos, Ppos)
   real, intent(in) :: dRhoPos !< Positive density difference [R ~> kg m-3]
   real, intent(in) :: Ppos    !< Position of positive density difference [R L2 T-2 ~> Pa] or [nondim]
 
-  character(len=120) :: mesg
+  character(len=256) :: mesg
 
   if ((Ppos > Pneg) .and. (dRhoPos - dRhoNeg >= 0. )) then
     if ( dRhoPos - dRhoNeg > 0. ) then


### PR DESCRIPTION
Increase neutral diffusion diagnostic buffer

`interpolate_for_nondim_position` builds a diagnostic string containing `dRhoNeg`, `Pneg`, `dRhoPos`, and `Ppos`. With Intel ifort, the existing `character(len=120)` buffer can overflow during the internal list-directed write before `MOM_error(FATAL)` is reached.

Increase the buffer to `character(len=256)` so the intended diagnostic is emitted before the fatal error, for example:
```
  dRhoNeg, Pneg, dRhoPos, Ppos -3.010545570431339E-002   208075.665823426
                    NaN   230137.296599796
```
Related issue: [mom-ocean/MOM6#1702.](https://github.com/mom-ocean/MOM6/issues/1702)