### PR TITLE
Only calculate Langmuir Number when LF17 SL Stokes drift is positive

### DIFF
--- a/src/user/MOM_wave_interface.F90
+++ b/src/user/MOM_wave_interface.F90
@@ -1462,7 +1462,7 @@ subroutine get_StokesSL_LiFoxKemper(ustar, hbl, GV, US, CS, UStokes_SL, LA)
       UStokes_sl = UStokes * (0.715 + ((r1 + r3) + r5))
     endif
 
-    if (UStokes_sl /= 0.0) LA = sqrt(US%Z_to_L*ustar / UStokes_sl)
+    if (UStokes_sl > 0.0) LA = sqrt(US%Z_to_L*ustar / UStokes_sl)
   endif
 
 end subroutine Get_StokesSL_LiFoxKemper


### PR DESCRIPTION
Closes #48