### PR TITLE
Add file-based dye tracer

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -257,6 +257,7 @@ target_sources(mom6shared PRIVATE
   tracer/DOME_tracer.F90
   tracer/dyed_obc_tracer.F90
   tracer/dye_example.F90
+  tracer/file_dye_tracer.F90
   tracer/ideal_age_example.F90
   tracer/ISOMIP_tracer.F90
   tracer/MOM_CFC_cap.F90

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -213,8 +213,8 @@ subroutine call_tracer_register(G, GV, US, param_file, CS, tr_Reg, restart_CS)
                  "If true, use the regional_dyes tracer package.", &
                  default=.false.)
   call get_param(param_file, mdl, "USE_FILE_DYES", CS%use_file_dyes, &
-       "If true, use the file dyes tracer package.", &
-       default=.false.)
+                 "If true, use the file dyes tracer package.", &
+                 default=.false.)
   call get_param(param_file, mdl, "USE_OIL_TRACER", CS%use_oil, &
                  "If true, use the oil_tracer tracer package.", &
                  default=.false.)
@@ -267,10 +267,10 @@ subroutine call_tracer_register(G, GV, US, param_file, CS, tr_Reg, restart_CS)
                         tr_Reg, restart_CS, CS%get_chl_from_MARBL)
   if (CS%use_regional_dyes) CS%use_regional_dyes = &
     register_dye_tracer(G%HI, GV, US, param_file, CS%dye_tracer_CSp, &
-    tr_Reg, restart_CS)
+                        tr_Reg, restart_CS)
   if (CS%use_file_dyes) CS%use_file_dyes = &
-       register_file_dye_tracer(G%HI, GV, US, param_file, CS%file_dye_tracer_CSp, &
-       tr_Reg, restart_CS)
+    register_file_dye_tracer(G%HI, GV, US, param_file, CS%file_dye_tracer_CSp, &
+                             tr_Reg, restart_CS)
   if (CS%use_oil) CS%use_oil = &
     register_oil_tracer(G%HI, GV, US, param_file,  CS%oil_tracer_CSp, &
                         tr_Reg, restart_CS)
@@ -356,9 +356,10 @@ subroutine tracer_flow_control_init(restart, day, G, GV, US, h, param_file, diag
     call initialize_MARBL_tracers(restart, day, G, GV, US, h, param_file, diag, OBC, CS%MARBL_tracers_CSp, &
                                 sponge_CSp)
   if (CS%use_regional_dyes) &
-       call initialize_dye_tracer(restart, day, G, GV, h, diag, OBC, CS%dye_tracer_CSp, sponge_CSp, tv)
+    call initialize_dye_tracer(restart, day, G, GV, h, diag, OBC, CS%dye_tracer_CSp, sponge_CSp, tv)
   if (CS%use_file_dyes) &
-       call initialize_file_dye_tracer(restart, day, G, GV, h, diag, OBC, CS%file_dye_tracer_CSp, sponge_CSp)
+    call initialize_file_dye_tracer(restart, day, G, GV, h, diag, OBC, CS%file_dye_tracer_CSp, &
+                                    sponge_CSp)
   if (CS%use_oil) &
     call initialize_oil_tracer(restart, day, G, GV, US, h, diag, OBC, CS%oil_tracer_CSp, sponge_CSp)
   if (CS%use_advection_test_tracer) &
@@ -553,9 +554,10 @@ subroutine call_tracer_column_fns(h_old, h_new, ea, eb, fluxes, mld, dt, G, GV, 
                                      evap_CFL_limit=evap_CFL_limit, &
                                      minimum_forcing_depth=minimum_forcing_depth)
     if (CS%use_file_dyes) &
-         call file_dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-         G, GV, US, CS%file_dye_tracer_CSp, &
-         evap_CFL_limit=evap_CFL_limit, minimum_forcing_depth=minimum_forcing_depth)
+      call file_dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+                                          G, GV, US, CS%file_dye_tracer_CSp, &
+                                          evap_CFL_limit=evap_CFL_limit, &
+                                          minimum_forcing_depth=minimum_forcing_depth)
     if (CS%use_oil) &
       call oil_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
                                      G, GV, US, CS%oil_tracer_CSp, tv, &
@@ -643,8 +645,8 @@ subroutine call_tracer_column_fns(h_old, h_new, ea, eb, fluxes, mld, dt, G, GV, 
       call dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
                                            G, GV, US, tv, CS%dye_tracer_CSp)
     if (CS%use_file_dyes) &
-         call file_dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
-         G, GV, US, CS%file_dye_tracer_CSp)
+      call file_dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+                                          G, GV, US, CS%file_dye_tracer_CSp)
     if (CS%use_oil) &
       call oil_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
                                      G, GV, US, CS%oil_tracer_CSp, tv)
@@ -773,12 +775,12 @@ subroutine call_tracer_stocks(h, stock_values, G, GV, US, CS, stock_names, stock
     ns = dye_stock(h, values_EFP, G, GV, CS%dye_tracer_CSp, names, units, stock_index)
     call store_stocks("regional_dyes", ns, names, units, values_EFP, index, stock_val_EFP, &
                       set_pkg_name, max_ns, ns_tot, stock_names, stock_units)
- endif
- if (CS%use_file_dyes) then
+  endif
+  if (CS%use_file_dyes) then
     ns = file_dye_stock(h, values_EFP, G, GV, CS%file_dye_tracer_CSp, names, units, stock_index)
     call store_stocks("file_dyes", ns, names, units, values_EFP, index, stock_val_EFP, &
-         set_pkg_name, max_ns, ns_tot, stock_names, stock_units)
- end if
+                      set_pkg_name, max_ns, ns_tot, stock_names, stock_units)
+  endif
   if (CS%use_oil) then
     ns = oil_stock(h, values_EFP, G, GV, CS%oil_tracer_CSp, names, units, stock_index)
     call store_stocks("oil_tracer", ns, names, units, values_EFP, index, stock_val_EFP, &
@@ -931,9 +933,9 @@ subroutine call_tracer_surface_state(sfc_state, h, G, GV, US, CS)
   if (CS%use_MARBL_tracers) &
     call MARBL_tracers_surface_state(sfc_state, G, US, CS%MARBL_tracers_CSp)
   if (CS%use_regional_dyes) &
-       call dye_tracer_surface_state(sfc_state, h, G, GV, CS%dye_tracer_CSp)
+    call dye_tracer_surface_state(sfc_state, h, G, GV, CS%dye_tracer_CSp)
   if (CS%use_file_dyes) &
-       call file_dye_tracer_surface_state(sfc_state, h, G, GV, CS%file_dye_tracer_CSp)
+    call file_dye_tracer_surface_state(sfc_state, h, G, GV, CS%file_dye_tracer_CSp)
   if (CS%use_oil) &
     call oil_tracer_surface_state(sfc_state, h, G, GV, CS%oil_tracer_CSp)
   if (CS%use_advection_test_tracer) &

--- a/src/tracer/MOM_tracer_flow_control.F90
+++ b/src/tracer/MOM_tracer_flow_control.F90
@@ -46,6 +46,9 @@ use MARBL_tracers, only : MARBL_tracers_stock, MARBL_tracers_end, MARBL_tracers_
 use regional_dyes, only : register_dye_tracer, initialize_dye_tracer
 use regional_dyes, only : dye_tracer_column_physics, dye_tracer_surface_state
 use regional_dyes, only : dye_stock, regional_dyes_end, dye_tracer_CS
+use file_dye_tracer, only : register_file_dye_tracer, initialize_file_dye_tracer
+use file_dye_tracer, only : file_dye_tracer_column_physics, file_dye_tracer_surface_state
+use file_dye_tracer, only : file_dye_stock, file_dyes_end, file_dye_tracer_CS
 use MOM_OCMIP2_CFC, only : register_OCMIP2_CFC, initialize_OCMIP2_CFC, flux_init_OCMIP2_CFC
 use MOM_OCMIP2_CFC, only : OCMIP2_CFC_column_physics, OCMIP2_CFC_surface_state
 use MOM_OCMIP2_CFC, only : OCMIP2_CFC_stock, OCMIP2_CFC_end, OCMIP2_CFC_CS
@@ -92,6 +95,7 @@ type, public :: tracer_flow_control_CS ; private
   logical :: use_ideal_age = .false.               !< If true, use the ideal age tracer package
   logical :: use_MARBL_tracers = .false.           !< If true, use the MARBL tracer package
   logical :: use_regional_dyes = .false.           !< If true, use the regional dyes tracer package
+  logical :: use_file_dyes = .false.               !< If true, use the file dyes tracer package
   logical :: use_oil = .false.                     !< If true, use the oil tracer package
   logical :: use_advection_test_tracer = .false.   !< If true, use the advection_test_tracer package
   logical :: use_OCMIP2_CFC = .false.              !< If true, use the OCMIP2_CFC tracer package
@@ -110,6 +114,7 @@ type, public :: tracer_flow_control_CS ; private
   type(ideal_age_tracer_CS), pointer :: ideal_age_tracer_CSp => NULL()
   type(MARBL_tracers_CS), pointer :: MARBL_tracers_CSp => NULL()
   type(dye_tracer_CS), pointer :: dye_tracer_CSp => NULL()
+  type(file_dye_tracer_CS), pointer :: file_dye_tracer_CSp => NULL()
   type(oil_tracer_CS), pointer :: oil_tracer_CSp => NULL()
   type(advection_test_tracer_CS), pointer :: advection_test_tracer_CSp => NULL()
   type(OCMIP2_CFC_CS), pointer :: OCMIP2_CFC_CSp => NULL()
@@ -207,6 +212,9 @@ subroutine call_tracer_register(G, GV, US, param_file, CS, tr_Reg, restart_CS)
   call get_param(param_file, mdl, "USE_REGIONAL_DYES", CS%use_regional_dyes, &
                  "If true, use the regional_dyes tracer package.", &
                  default=.false.)
+  call get_param(param_file, mdl, "USE_FILE_DYES", CS%use_file_dyes, &
+       "If true, use the file dyes tracer package.", &
+       default=.false.)
   call get_param(param_file, mdl, "USE_OIL_TRACER", CS%use_oil, &
                  "If true, use the oil_tracer tracer package.", &
                  default=.false.)
@@ -259,7 +267,10 @@ subroutine call_tracer_register(G, GV, US, param_file, CS, tr_Reg, restart_CS)
                         tr_Reg, restart_CS, CS%get_chl_from_MARBL)
   if (CS%use_regional_dyes) CS%use_regional_dyes = &
     register_dye_tracer(G%HI, GV, US, param_file, CS%dye_tracer_CSp, &
-                        tr_Reg, restart_CS)
+    tr_Reg, restart_CS)
+  if (CS%use_file_dyes) CS%use_file_dyes = &
+       register_file_dye_tracer(G%HI, GV, US, param_file, CS%file_dye_tracer_CSp, &
+       tr_Reg, restart_CS)
   if (CS%use_oil) CS%use_oil = &
     register_oil_tracer(G%HI, GV, US, param_file,  CS%oil_tracer_CSp, &
                         tr_Reg, restart_CS)
@@ -345,7 +356,9 @@ subroutine tracer_flow_control_init(restart, day, G, GV, US, h, param_file, diag
     call initialize_MARBL_tracers(restart, day, G, GV, US, h, param_file, diag, OBC, CS%MARBL_tracers_CSp, &
                                 sponge_CSp)
   if (CS%use_regional_dyes) &
-    call initialize_dye_tracer(restart, day, G, GV, h, diag, OBC, CS%dye_tracer_CSp, sponge_CSp, tv)
+       call initialize_dye_tracer(restart, day, G, GV, h, diag, OBC, CS%dye_tracer_CSp, sponge_CSp, tv)
+  if (CS%use_file_dyes) &
+       call initialize_file_dye_tracer(restart, day, G, GV, h, diag, OBC, CS%file_dye_tracer_CSp, sponge_CSp)
   if (CS%use_oil) &
     call initialize_oil_tracer(restart, day, G, GV, US, h, diag, OBC, CS%oil_tracer_CSp, sponge_CSp)
   if (CS%use_advection_test_tracer) &
@@ -539,6 +552,10 @@ subroutine call_tracer_column_fns(h_old, h_new, ea, eb, fluxes, mld, dt, G, GV, 
                                      G, GV, US, tv, CS%dye_tracer_CSp, &
                                      evap_CFL_limit=evap_CFL_limit, &
                                      minimum_forcing_depth=minimum_forcing_depth)
+    if (CS%use_file_dyes) &
+         call file_dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+         G, GV, US, CS%file_dye_tracer_CSp, &
+         evap_CFL_limit=evap_CFL_limit, minimum_forcing_depth=minimum_forcing_depth)
     if (CS%use_oil) &
       call oil_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
                                      G, GV, US, CS%oil_tracer_CSp, tv, &
@@ -625,6 +642,9 @@ subroutine call_tracer_column_fns(h_old, h_new, ea, eb, fluxes, mld, dt, G, GV, 
     if (CS%use_regional_dyes) &
       call dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
                                            G, GV, US, tv, CS%dye_tracer_CSp)
+    if (CS%use_file_dyes) &
+         call file_dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
+         G, GV, US, CS%file_dye_tracer_CSp)
     if (CS%use_oil) &
       call oil_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, &
                                      G, GV, US, CS%oil_tracer_CSp, tv)
@@ -753,7 +773,12 @@ subroutine call_tracer_stocks(h, stock_values, G, GV, US, CS, stock_names, stock
     ns = dye_stock(h, values_EFP, G, GV, CS%dye_tracer_CSp, names, units, stock_index)
     call store_stocks("regional_dyes", ns, names, units, values_EFP, index, stock_val_EFP, &
                       set_pkg_name, max_ns, ns_tot, stock_names, stock_units)
-  endif
+ endif
+ if (CS%use_file_dyes) then
+    ns = file_dye_stock(h, values_EFP, G, GV, CS%file_dye_tracer_CSp, names, units, stock_index)
+    call store_stocks("file_dyes", ns, names, units, values_EFP, index, stock_val_EFP, &
+         set_pkg_name, max_ns, ns_tot, stock_names, stock_units)
+ end if
   if (CS%use_oil) then
     ns = oil_stock(h, values_EFP, G, GV, CS%oil_tracer_CSp, names, units, stock_index)
     call store_stocks("oil_tracer", ns, names, units, values_EFP, index, stock_val_EFP, &
@@ -906,7 +931,9 @@ subroutine call_tracer_surface_state(sfc_state, h, G, GV, US, CS)
   if (CS%use_MARBL_tracers) &
     call MARBL_tracers_surface_state(sfc_state, G, US, CS%MARBL_tracers_CSp)
   if (CS%use_regional_dyes) &
-    call dye_tracer_surface_state(sfc_state, h, G, GV, CS%dye_tracer_CSp)
+       call dye_tracer_surface_state(sfc_state, h, G, GV, CS%dye_tracer_CSp)
+  if (CS%use_file_dyes) &
+       call file_dye_tracer_surface_state(sfc_state, h, G, GV, CS%file_dye_tracer_CSp)
   if (CS%use_oil) &
     call oil_tracer_surface_state(sfc_state, h, G, GV, CS%oil_tracer_CSp)
   if (CS%use_advection_test_tracer) &
@@ -930,6 +957,7 @@ subroutine tracer_flow_control_end(CS)
   if (CS%use_ideal_age) call ideal_age_example_end(CS%ideal_age_tracer_CSp)
   if (CS%use_MARBL_tracers) call MARBL_tracers_end(CS%MARBL_tracers_CSp)
   if (CS%use_regional_dyes) call regional_dyes_end(CS%dye_tracer_CSp)
+  if (CS%use_file_dyes) call file_dyes_end(CS%file_dye_tracer_CSp)
   if (CS%use_oil) call oil_tracer_end(CS%oil_tracer_CSp)
   if (CS%use_advection_test_tracer) call advection_test_tracer_end(CS%advection_test_tracer_CSp)
   if (CS%use_OCMIP2_CFC) call OCMIP2_CFC_end(CS%OCMIP2_CFC_CSp)

--- a/src/tracer/file_dye_tracer.F90
+++ b/src/tracer/file_dye_tracer.F90
@@ -1,24 +1,25 @@
 !> A tracer package for injecting dyes from file
 module file_dye_tracer
 
-use MOM_coms, only : EFP_type
-use MOM_diag_mediator, only : diag_ctrl
-use MOM_error_handler, only : MOM_error, FATAL
-use MOM_file_parser, only : get_param, log_version, param_file_type
-use MOM_forcing_type, only : forcing
-use MOM_grid, only : ocean_grid_type
-use MOM_hor_index, only : hor_index_type
-use MOM_io, only : file_exists, MOM_read_data, query_vardesc, slasher, vardesc, var_desc
-use MOM_open_boundary, only : ocean_OBC_type
-use MOM_restart, only : MOM_restart_CS
-use MOM_spatial_means, only : global_mass_int_EFP
-use MOM_sponge, only : sponge_CS
-use MOM_time_manager, only : time_type
+use MOM_coms,            only : EFP_type
+use MOM_diag_mediator,   only : diag_ctrl
+use MOM_error_handler,   only : MOM_error, FATAL
+use MOM_file_parser,     only : get_param, log_version, param_file_type
+use MOM_forcing_type,    only : forcing
+use MOM_grid,            only : ocean_grid_type
+use MOM_hor_index,       only : hor_index_type
+use MOM_io,              only : MOM_read_data, file_exists, query_vardesc
+use MOM_io,              only : slasher, vardesc, var_desc
+use MOM_open_boundary,   only : ocean_OBC_type
+use MOM_restart,         only : MOM_restart_CS
+use MOM_spatial_means,   only : global_mass_int_EFP
+use MOM_sponge,          only : sponge_CS
+use MOM_time_manager,    only : time_type
 use MOM_tracer_diabatic, only : applyTracerBoundaryFluxesInOut, tracer_vertdiff
 use MOM_tracer_registry, only : register_tracer, tracer_registry_type
-use MOM_unit_scaling, only : unit_scalE_type
-use MOM_variables, only : surface
-use MOM_verticalGrid, only : verticalGrid_type
+use MOM_unit_scaling,    only : unit_scale_type
+use MOM_variables,       only : surface
+use MOM_verticalGrid,    only : verticalGrid_type
 
 implicit none ; private
 
@@ -30,114 +31,134 @@ public file_dye_stock, file_dyes_end
 
 !> The control structure for the file_dye_tracer module
 type, public :: file_dye_tracer_CS ; private
-  integer :: ntr !< The number of tracers that are actually used
-  character(len=200) :: tracer_file !< Path to the tracer IC file
-  character(len=200) :: inputdir !< Input directory
-  type(vardesc), allocatable :: tr_desc(:) !< Descriptions and metadata for tracers
-  real, pointer :: tr(:,:,:,:) => NULL() !< Array of tracers
-  real, pointer :: tr_source(:,:,:,:) => NULL() !< Array of tracer source fields
-  logical :: tracers_may_reinit = .false. !< If true, tracers may be initialized if not in a restart file
+  !> The number of tracers that are actually used
+  integer :: ntr
 
-  type(tracer_registry_type), pointer :: tr_Reg => NULL() !< Tracer registry (pointer)
-  type(MOM_restart_CS), pointer :: restart_CSp => NULL() !< Restart control structure (pointer)
-  type(diag_ctrl), pointer :: diag => NULL() !< Diag control (pointer)
+  !> Path to the tracer IC file
+  character(len=200) :: tracer_file
+
+  !> Input directory
+  character(len=200) :: inputdir
+
+  !> Descriptions and metadata for tracers
+  type(vardesc), allocatable :: tr_desc(:)
+
+  !> Array of tracers
+  real, pointer :: tr(:,:,:,:) => NULL()
+
+  !> Array of tracer source fields
+  real, pointer :: tr_source(:,:,:,:) => NULL()
+
+  !> If true, tracers may be initialized if not in a restart file
+  logical :: tracers_may_reinit = .false.
+
+  !> Tracer registry (pointer)
+  type(tracer_registry_type), pointer :: tr_Reg => NULL()
+
+  !> Restart control structure (pointer)
+  type(MOM_restart_CS), pointer :: restart_CSp => NULL()
+
+  !> Diag control (pointer)
+  type(diag_ctrl), pointer :: diag => NULL()
+
 end type file_dye_tracer_CS
 
 contains
 
 !> This subroutine is used to register tracer fields and subroutines to be used with MOM.
 function register_file_dye_tracer(HI, GV, US, param_file, CS, tr_Reg, restart_CS)
- type(hor_index_type), intent(in) :: HI                    !< The domain horizontal indexing
- type(verticalGrid_type), intent(in) :: GV                 !< The ocean's vertical grid structure
- type(unit_scale_type), intent(in) :: US                   !< A dimensional unit scaling type
- type(param_file_type), intent(in) :: param_file           !< A structure to parse for run-time parameters
- type(file_dye_tracer_CS), pointer :: CS                   !< A pointer to this module's control structure
- type(tracer_registry_type), pointer :: tr_Reg             !< A pointer to the tracer registry
- type(MOM_restart_CS), target, intent(inout) :: restart_CS !< MOM restart control struct
+  type(hor_index_type), intent(in) :: HI          !< The domain horizontal indexing
+  type(verticalGrid_type), intent(in) :: GV       !< The ocean's vertical grid structure
+  type(unit_scale_type), intent(in) :: US         !< A dimensional unit scaling type
+  type(param_file_type), intent(in) :: param_file !< A structure to parse for run-time parameters
+  type(file_dye_tracer_CS), pointer :: CS         !< A pointer to this module's control structure
+  type(tracer_registry_type), pointer :: tr_Reg   !< A pointer to the tracer registry
+  type(MOM_restart_CS), target, intent(inout) :: restart_CS !< MOM restart control struct
 
- logical :: register_file_dye_tracer
- character(len=40) :: mdl = "file_dyes"
- character(len=48) :: var_name, desc_name
+  logical :: register_file_dye_tracer
+  character(len=40) :: mdl = "file_dyes"
+  character(len=48) :: var_name, desc_name
 #include "version_variable.h"
- real, pointer :: tr_ptr(:,:,:) => NULL()
- integer :: m
- integer :: isd, ied, jsd, jed, nz
- isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
+  real, pointer :: tr_ptr(:,:,:) => NULL()
+  integer :: m
+  integer :: isd, ied, jsd, jed, nz
+  isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
 
- register_file_dye_tracer = .false.
+  register_file_dye_tracer = .false.
 
- if (associated(CS)) then
+  if (associated(CS)) then
     call MOM_error(FATAL, "register_file_dye_tracer called with an "// &
-         "associated control structure.")
- end if
- allocate(CS)
+                   "associated control structure.")
+  end if
+  allocate(CS)
 
- call log_version(param_file, mdl, version, "")
- call get_param(param_file, mdl, "FILE_DYE_TRACERS_FILE", CS%tracer_file, &
-      "The name of a file from which to read the initial conditions for the tracers", &
-      default="")
- ! expect a file, maybe make this fatal
- if (len_trim(CS%tracer_file) == 0) return
+  call log_version(param_file, mdl, version, "")
+  call get_param(param_file, mdl, "FILE_DYE_TRACERS_FILE", CS%tracer_file, &
+                 "The name of a file from which to read the initial conditions for the tracers", &
+                 default="")
+  ! expect a file, maybe make this fatal
+  if (len_trim(CS%tracer_file) == 0) return
 
- call get_param(param_file, mdl, "NUM_FILE_DYE_TRACERS", CS%ntr, &
-      "The number of file-based dye tracers in this run.", &
-      default=0)
+  call get_param(param_file, mdl, "NUM_FILE_DYE_TRACERS", CS%ntr, &
+                 "The number of file-based dye tracers in this run.", &
+                 default=0)
 
- call get_param(param_file, mdl, "INPUTDIR", CS%inputdir, default=".")
- CS%inputdir = slasher(CS%inputdir)
+  call get_param(param_file, mdl, "INPUTDIR", CS%inputdir, default=".")
+  CS%inputdir = slasher(CS%inputdir)
 
- allocate(CS%tr_desc(CS%ntr))
+  allocate(CS%tr_desc(CS%ntr))
 
- allocate(CS%tr(isd:ied,jsd:jed,nz,CS%ntr), source=0.0)
- allocate(CS%tr_source(isd:ied,jsd:jed,nz,CS%ntr), source=0.0)
+  allocate(CS%tr(isd:ied,jsd:jed,nz,CS%ntr), source=0.0)
+  allocate(CS%tr_source(isd:ied,jsd:jed,nz,CS%ntr), source=0.0)
 
- do m = 1, CS%ntr
+  do m = 1, CS%ntr
     write(var_name(:), '(A,I3.3)') "dye", m
     write(desc_name(:), '(A,I3.3)') "Dye Tracer ", m
     CS%tr_desc(m) = var_desc(trim(var_name), "conc", trim(desc_name), caller=mdl)
     tr_ptr => CS%tr(:,:,:,m)
     call query_vardesc(CS%tr_desc(m), name=var_name, &
-         caller="register_file_dye_tracer")
+                       caller="register_file_dye_tracer")
     call register_tracer(tr_ptr, tr_Reg, param_file, HI, GV, &
-         tr_desc=CS%tr_desc(m), registry_diags=.true., &
-         restart_CS=restart_CS, mandatory=.not. CS%tracers_may_reinit)
- end do
+                         tr_desc=CS%tr_desc(m), registry_diags=.true., &
+                         restart_CS=restart_CS, mandatory=.not. CS%tracers_may_reinit)
+  end do
 
- CS%tr_Reg => tr_Reg
- CS%restart_CSp => restart_CS
- register_file_dye_tracer = .true.
+  CS%tr_Reg => tr_Reg
+  CS%restart_CSp => restart_CS
+  register_file_dye_tracer = .true.
 end function register_file_dye_tracer
 
 !> This subroutine initializes the NTR tracer fields in tr(:,:,:,:)
 !! and it sets up the tracer output.
 subroutine initialize_file_dye_tracer(restart, day, G, GV, h, diag, OBC, CS, sponge_CSp)
- logical, intent(in) :: restart                             !< fields already read from a restart file
- type(time_type), target, intent(in) :: day                 !< Time of start of run
- type(ocean_grid_type), intent(in) :: G                     !< The ocean's grid structure
- type(verticalGrid_type), intent(in) :: GV                  !< The ocean's vertical grid structure
- real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in) :: h !< Layer thicknesses [H ~> m or kg m-2]
- type(diag_ctrl), target, intent(in) :: diag                !< Diagnostic control structure
- type(ocean_OBC_type), pointer :: OBC                       !< Open boundary control structure
- type(file_dye_tracer_CS), pointer :: CS                    !< This module's control structure
- type(sponge_CS), pointer :: sponge_CSp                     !< Sponge control structure
+  logical, intent(in) :: restart              !< fields already read from a restart file
+  type(time_type), target, intent(in) :: day  !< Time of start of run
+  type(ocean_grid_type), intent(in) :: G      !< The ocean's grid structure
+  type(verticalGrid_type), intent(in) :: GV   !< The ocean's vertical grid structure
+  real, intent(in), &
+    dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h  !< Layer thicknesses [H ~> m or kg m-2]
+  type(diag_ctrl), target, intent(in) :: diag !< Diagnostic control structure
+  type(ocean_OBC_type), pointer :: OBC        !< Open boundary control structure
+  type(file_dye_tracer_CS), pointer :: CS     !< This module's control structure
+  type(sponge_CS), pointer :: sponge_CSp      !< Sponge control structure
 
- integer :: m
- character(len=32) :: name
+  integer :: m
+  character(len=32) :: name
 
- if (.not. associated(CS)) return
- if (CS%ntr < 1) return
+  if (.not. associated(CS)) return
+  if (CS%ntr < 1) return
 
- CS%diag => diag
+  CS%diag => diag
 
- if (.not. file_exists(trim(CS%inputdir)//trim(CS%tracer_file), G%Domain)) then
+  if (.not. file_exists(trim(CS%inputdir)//trim(CS%tracer_file), G%Domain)) then
     call MOM_error(FATAL, "initialize_file_dye_tracer: Unable to open " // &
-         CS%tracer_file)
- end if
+                   CS%tracer_file)
+  end if
 
- do m = 1, CS%ntr
+  do m = 1, CS%ntr
     call query_vardesc(CS%tr_desc(m), name, caller="initialize_file_dye_tracer")
     call MOM_read_data(trim(CS%inputdir)//trim(CS%tracer_file), trim(name), CS%tr_source(:,:,:,m), G%Domain)
- end do
+  end do
 
 end subroutine initialize_file_dye_tracer
 
@@ -147,118 +168,120 @@ end subroutine initialize_file_dye_tracer
 !! The arguments to this subroutine are redundant in that
 !!     h_new(k) = h_old(k) + ea(k) - eb(k-1) + eb(k) - ea(k+1)
 subroutine file_dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US, CS, &
-    evap_CFL_limit, minimum_forcing_depth)
- type(ocean_grid_type),   intent(in) :: G                     !< The ocean's grid structure
- type(verticalGrid_type), intent(in) :: GV                    !< The ocean's vertical grid structure
- real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                          intent(in) :: h_old                 !< Layer thickness before entrainment [H ~> m or kg m-2]
- real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                          intent(in) :: h_new                 !< Layer thickness after entrainment [H ~> m or kg m-2]
- real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                          intent(in) :: ea                    !< An array to which the amount of fluid entrained
-                                                              !! from the layer above during this call will be
-                                                              !! added [H ~> m or kg m-2].
- real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
-                          intent(in) :: eb                    !< An array to which the amount of fluid entrained
-                                                              !! from the layer below during this call will be
-                                                              !! added [H ~> m or kg m-2].
- type(forcing),           intent(in) :: fluxes                !< A structure with pointers to forcing fields
- real,                    intent(in) :: dt                    !< Amount of time covered by this call [T ~> s]
- type(unit_scale_type),   intent(in) :: US                    !< A dimensional unit scaling type
- type(file_dye_tracer_CS), pointer :: CS                      !< This module's control structure
- real, optional,          intent(in) :: evap_CFL_limit        !< Limit on the fraction of the water that can
-                                                              !! be fluxed out of the top layer in a timestep [nondim]
- real, optional,          intent(in) :: minimum_forcing_depth !< The smallest depth over which
-                                                              !! fluxes can be applied [H ~> m or kg m-2]
+                                          evap_CFL_limit, minimum_forcing_depth)
+  type(ocean_grid_type), intent(in) :: G       !< The ocean's grid structure
+  type(verticalGrid_type), intent(in) :: GV    !< The ocean's vertical grid structure
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+    intent(in) :: h_old                        !< Layer thickness before entrainment [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+    intent(in) :: h_new                        !< Layer thickness after entrainment [H ~> m or kg m-2]
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+    intent(in) :: ea                           !< An array to which the amount of fluid entrained
+                                               !! from the layer above during this call will be
+                                               !! added [H ~> m or kg m-2].
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+    intent(in) :: eb                           !< An array to which the amount of fluid entrained
+                                               !! from the layer below during this call will be
+                                               !! added [H ~> m or kg m-2].
+  type(forcing), intent(in) :: fluxes          !< A structure with pointers to forcing fields
+  real, intent(in) :: dt                       !< Amount of time covered by this call [T ~> s]
+  type(unit_scale_type), intent(in) :: US      !< A dimensional unit scaling type
+  type(file_dye_tracer_CS), pointer :: CS      !< This module's control structure
+  real, optional, intent(in) :: evap_CFL_limit !< Limit on the fraction of the water that can
+                                               !! be fluxed out of the top layer in a timestep [nondim]
+  real, optional, intent(in) :: minimum_forcing_depth !< The smallest depth over which
+                                                      !! fluxes can be applied [H ~> m or kg m-2]
 
- integer :: m
- integer :: is, ie, js, je, nz
- real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h_work
+  integer :: m
+  integer :: is, ie, js, je, nz
+  real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h_work
 
- is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
+  is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
 
- if (.not. associated(CS)) return
- if (CS%ntr < 1) return
+  if (.not. associated(CS)) return
+  if (CS%ntr < 1) return
 
- if (present(evap_CFL_limit) .and. present(minimum_forcing_depth)) then
+  if (present(evap_CFL_limit) .and. present(minimum_forcing_depth)) then
     do m = 1, CS%ntr
-       h_work(is:ie,js:je,1:nz) = h_old(is:ie,js:je,1:nz)
+      h_work(is:ie,js:je,1:nz) = h_old(is:ie,js:je,1:nz)
 
-       call applyTracerBoundaryFluxesInOut(G, GV, CS%tr(:,:,:,m), dt, fluxes, h_work, &
-            evap_CFL_limit, minimum_forcing_depth)
-       call tracer_vertdiff(h_work, ea, eb, dt, CS%tr(:,:,:,m), G, GV)
+      call applyTracerBoundaryFluxesInOut(G, GV, CS%tr(:,:,:,m), dt, fluxes, h_work, &
+                                          evap_CFL_limit, minimum_forcing_depth)
+      call tracer_vertdiff(h_work, ea, eb, dt, CS%tr(:,:,:,m), G, GV)
     end do
- else
+  else
     do m = 1, CS%ntr
-       call tracer_vertdiff(h_old, ea, eb, dt, CS%tr(:,:,:,m), G, GV)
+      call tracer_vertdiff(h_old, ea, eb, dt, CS%tr(:,:,:,m), G, GV)
     end do
- end if
+  end if
 
- ! add from source every timestep
- do m = 1, CS%ntr
+  ! add from source every timestep
+  do m = 1, CS%ntr
     CS%tr(is:ie,js:je,1:nz,m) = CS%tr(is:ie,js:je,1:nz,m) + CS%tr_source(is:ie,js:je,1:nz,m)
- end do
+  end do
 end subroutine file_dye_tracer_column_physics
 
 !> This subroutine extracts the surface fields from this tracer package that
 !! are to be shared with the atmosphere in coupled configurations.
 subroutine file_dye_tracer_surface_state(sfc_state, h, G, GV, CS)
- type(ocean_grid_type), intent(in) :: G                     !< The ocean's grid structure
- type(verticalGrid_type), intent(in) :: GV                  !< The ocean's vertical grid structure
- type(surface), intent(inout) :: sfc_state                  !< A structure containing surface state fields
- real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in) :: h !< Layer thickness [H ~> m or kg m-2]
- type(file_dye_tracer_CS), pointer :: CS                    !< This module's control structure
+  type(ocean_grid_type), intent(in) :: G     !< The ocean's grid structure
+  type(verticalGrid_type), intent(in) :: GV  !< The ocean's vertical grid structure
+  type(surface), intent(inout) :: sfc_state  !< A structure containing surface state fields
+  real, intent(in), &
+    dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h !< Layer thickness [H ~> m or kg m-2]
+  type(file_dye_tracer_CS), pointer :: CS    !< This module's control structure
 
- if (.not. associated(CS)) return
+  if (.not. associated(CS)) return
 
- ! we would potentially couple the surface to the coupler here
+  ! we would potentially couple the surface to the coupler here
 end subroutine file_dye_tracer_surface_state
 
 !> This function calculates the mass-weighted integral of all tracer stocks,
 !! returning the number of stocks it has calculated.  If the stock_index
 !! is present, only the stock corresponding to that coded index is returned.
 function file_dye_stock(h, stocks, G, GV, CS, names, units, stock_index)
- type(ocean_grid_type), intent(in) :: G                     !< The ocean's grid structure
- type(verticalGrid_type), intent(in) :: GV                  !< The ocean's vertical grid structure
- real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in) :: h !< Layer thickness [H ~> m or kg m-2]
- type(EFP_type), intent(out) :: stocks(:)                   !< Mass-weighted integrated amount of each
-                                                            !! tracer, in kg times concentration units [kg conc].
- type(file_dye_tracer_CS), pointer :: CS                    !< This module's control structure
- character(len=*), intent(out) :: names(:)                  !< The names of the stocks calculated
- character(len=*), intent(out) :: units(:)                  !< The units of the stocks calculated
- integer, optional, intent(in) :: stock_index               !< The number of stocks calculated here
+  type(ocean_grid_type), intent(in) :: G       !< The ocean's grid structure
+  type(verticalGrid_type), intent(in) :: GV    !< The ocean's vertical grid structure
+  real, intent(in), &
+    dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h   !< Layer thickness [H ~> m or kg m-2]
+  type(EFP_type), intent(out) :: stocks(:)     !< Mass-weighted integrated amount of each
+                                               !! tracer, in kg times concentration units [kg conc].
+  type(file_dye_tracer_CS), pointer :: CS      !< This module's control structure
+  character(len=*), intent(out) :: names(:)    !< The names of the stocks calculated
+  character(len=*), intent(out) :: units(:)    !< The units of the stocks calculated
+  integer, optional, intent(in) :: stock_index !< The number of stocks calculated here
 
- integer :: file_dye_stock
+  integer :: file_dye_stock
 
- integer :: m
+  integer :: m
 
- file_dye_stock = 0
- if (.not. associated(CS)) return
- if (CS%ntr < 1) return
+  file_dye_stock = 0
+  if (.not. associated(CS)) return
+  if (CS%ntr < 1) return
 
- if (present(stock_index)) then ; if (stock_index > 0) then
-    ! check whether this stock is available...
-    return
- end if ; end if
+  if (present(stock_index)) then ; if (stock_index > 0) then
+      ! check whether this stock is available...
+      return
+    end if ; end if
 
- do m = 1, CS%ntr
+  do m = 1, CS%ntr
     call query_vardesc(CS%tr_desc(m), name=names(m), units=units(m), caller="file_dye_stock")
     units(m) = trim(units(m)) // " kg"
     stocks(m) = global_mass_int_EFP(h, G, GV, CS%tr(:,:,:,m), on_PE_only=.true.)
- end do
+  end do
 
- file_dye_stock = CS%ntr
+  file_dye_stock = CS%ntr
 end function file_dye_stock
 
 !> Deallocate memory associated with this module
 subroutine file_dyes_end(CS)
- type(file_dye_tracer_CS), pointer :: CS !< This module's control structure
+  type(file_dye_tracer_CS), pointer :: CS !< This module's control structure
 
- if (associated(CS)) then
+  if (associated(CS)) then
     if (associated(CS%tr)) deallocate(CS%tr)
     if (associated(CS%tr_source)) deallocate(CS%tr_source)
     deallocate(CS)
- end if
+  end if
 end subroutine file_dyes_end
 
 end module file_dye_tracer

--- a/src/tracer/file_dye_tracer.F90
+++ b/src/tracer/file_dye_tracer.F90
@@ -33,7 +33,6 @@ type, public :: file_dye_tracer_CS ; private
   integer :: ntr !< The number of tracers that are actually used
   character(len=200) :: tracer_file !< Path to the tracer IC file
   character(len=200) :: inputdir !< Input directory
-  integer, allocatable :: ind_tr(:) !< Tracer indices for the coupler
   type(vardesc), allocatable :: tr_desc(:) !< Descriptions and metadata for tracers
   real, pointer :: tr(:,:,:,:) => NULL() !< Array of tracers
   real, pointer :: tr_source(:,:,:,:) => NULL() !< Array of tracer source fields
@@ -68,7 +67,7 @@ function register_file_dye_tracer(HI, GV, US, param_file, CS, tr_Reg, restart_CS
  register_file_dye_tracer = .false.
 
  if (associated(CS)) then
-    call MOM_error(FATAL, "registr_file_dye_tracer called with an "// &
+    call MOM_error(FATAL, "register_file_dye_tracer called with an "// &
          "associated control structure.")
  end if
  allocate(CS)
@@ -87,7 +86,6 @@ function register_file_dye_tracer(HI, GV, US, param_file, CS, tr_Reg, restart_CS
  call get_param(param_file, mdl, "INPUTDIR", CS%inputdir, default=".")
  CS%inputdir = slasher(CS%inputdir)
 
- allocate(CS%ind_tr(CS%ntr))
  allocate(CS%tr_desc(CS%ntr))
 
  allocate(CS%tr(isd:ied,jsd:jed,nz,CS%ntr), source=0.0)
@@ -111,7 +109,7 @@ function register_file_dye_tracer(HI, GV, US, param_file, CS, tr_Reg, restart_CS
 end function register_file_dye_tracer
 
 !> This subroutine initializes the NTR tracer fields in tr(:,:,:,:)
-! !! and it sets up the tracer output.
+!! and it sets up the tracer output.
 subroutine initialize_file_dye_tracer(restart, day, G, GV, h, diag, OBC, CS, sponge_CSp)
  logical, intent(in) :: restart                             !< fields already read from a restart file
  type(time_type), target, intent(in) :: day                 !< Time of start of run
@@ -132,7 +130,7 @@ subroutine initialize_file_dye_tracer(restart, day, G, GV, h, diag, OBC, CS, spo
  CS%diag => diag
 
  if (.not. file_exists(trim(CS%inputdir)//trim(CS%tracer_file), G%Domain)) then
-    call MOM_error(FATAL, "initial_file_dye_tracer: Unable to open " // &
+    call MOM_error(FATAL, "initialize_file_dye_tracer: Unable to open " // &
          CS%tracer_file)
  end if
 
@@ -245,7 +243,7 @@ function file_dye_stock(h, stocks, G, GV, CS, names, units, stock_index)
 
  do m = 1, CS%ntr
     call query_vardesc(CS%tr_desc(m), name=names(m), units=units(m), caller="file_dye_stock")
-    units(m) = trim(units(m)) // "kg"
+    units(m) = trim(units(m)) // " kg"
     stocks(m) = global_mass_int_EFP(h, G, GV, CS%tr(:,:,:,m), on_PE_only=.true.)
  end do
 
@@ -258,6 +256,7 @@ subroutine file_dyes_end(CS)
 
  if (associated(CS)) then
     if (associated(CS%tr)) deallocate(CS%tr)
+    if (associated(CS%tr_source)) deallocate(CS%tr_source)
     deallocate(CS)
  end if
 end subroutine file_dyes_end

--- a/src/tracer/file_dye_tracer.F90
+++ b/src/tracer/file_dye_tracer.F90
@@ -1,0 +1,265 @@
+!> A tracer package for injecting dyes from file
+module file_dye_tracer
+
+use MOM_coms, only : EFP_type
+use MOM_diag_mediator, only : diag_ctrl
+use MOM_error_handler, only : MOM_error, FATAL
+use MOM_file_parser, only : get_param, log_version, param_file_type
+use MOM_forcing_type, only : forcing
+use MOM_grid, only : ocean_grid_type
+use MOM_hor_index, only : hor_index_type
+use MOM_io, only : file_exists, MOM_read_data, query_vardesc, slasher, vardesc, var_desc
+use MOM_open_boundary, only : ocean_OBC_type
+use MOM_restart, only : MOM_restart_CS
+use MOM_spatial_means, only : global_mass_int_EFP
+use MOM_sponge, only : sponge_CS
+use MOM_time_manager, only : time_type
+use MOM_tracer_diabatic, only : applyTracerBoundaryFluxesInOut, tracer_vertdiff
+use MOM_tracer_registry, only : register_tracer, tracer_registry_type
+use MOM_unit_scaling, only : unit_scalE_type
+use MOM_variables, only : surface
+use MOM_verticalGrid, only : verticalGrid_type
+
+implicit none ; private
+
+#include <MOM_memory.h>
+
+public register_file_dye_tracer, initialize_file_dye_tracer
+public file_dye_tracer_column_physics, file_dye_tracer_surface_state
+public file_dye_stock, file_dyes_end
+
+!> The control structure for the file_dye_tracer module
+type, public :: file_dye_tracer_CS ; private
+  integer :: ntr !< The number of tracers that are actually used
+  character(len=200) :: tracer_file !< Path to the tracer IC file
+  character(len=200) :: inputdir !< Input directory
+  integer, allocatable :: ind_tr(:) !< Tracer indices for the coupler
+  type(vardesc), allocatable :: tr_desc(:) !< Descriptions and metadata for tracers
+  real, pointer :: tr(:,:,:,:) => NULL() !< Array of tracers
+  real, pointer :: tr_source(:,:,:,:) => NULL() !< Array of tracer source fields
+  logical :: tracers_may_reinit = .false. !< If true, tracers may be initialized if not in a restart file
+
+  type(tracer_registry_type), pointer :: tr_Reg => NULL() !< Tracer registry (pointer)
+  type(MOM_restart_CS), pointer :: restart_CSp => NULL() !< Restart control structure (pointer)
+  type(diag_ctrl), pointer :: diag => NULL() !< Diag control (pointer)
+end type file_dye_tracer_CS
+
+contains
+
+!> This subroutine is used to register tracer fields and subroutines to be used with MOM.
+function register_file_dye_tracer(HI, GV, US, param_file, CS, tr_Reg, restart_CS)
+ type(hor_index_type), intent(in) :: HI                    !< The domain horizontal indexing
+ type(verticalGrid_type), intent(in) :: GV                 !< The ocean's vertical grid structure
+ type(unit_scale_type), intent(in) :: US                   !< A dimensional unit scaling type
+ type(param_file_type), intent(in) :: param_file           !< A structure to parse for run-time parameters
+ type(file_dye_tracer_CS), pointer :: CS                   !< A pointer to this module's control structure
+ type(tracer_registry_type), pointer :: tr_Reg             !< A pointer to the tracer registry
+ type(MOM_restart_CS), target, intent(inout) :: restart_CS !< MOM restart control struct
+
+ logical :: register_file_dye_tracer
+ character(len=40) :: mdl = "file_dyes"
+ character(len=48) :: var_name, desc_name
+#include "version_variable.h"
+ real, pointer :: tr_ptr(:,:,:) => NULL()
+ integer :: m
+ integer :: isd, ied, jsd, jed, nz
+ isd = HI%isd ; ied = HI%ied ; jsd = HI%jsd ; jed = HI%jed ; nz = GV%ke
+
+ register_file_dye_tracer = .false.
+
+ if (associated(CS)) then
+    call MOM_error(FATAL, "registr_file_dye_tracer called with an "// &
+         "associated control structure.")
+ end if
+ allocate(CS)
+
+ call log_version(param_file, mdl, version, "")
+ call get_param(param_file, mdl, "FILE_DYE_TRACERS_FILE", CS%tracer_file, &
+      "The name of a file from which to read the initial conditions for the tracers", &
+      default="")
+ ! expect a file, maybe make this fatal
+ if (len_trim(CS%tracer_file) == 0) return
+
+ call get_param(param_file, mdl, "NUM_FILE_DYE_TRACERS", CS%ntr, &
+      "The number of file-based dye tracers in this run.", &
+      default=0)
+
+ call get_param(param_file, mdl, "INPUTDIR", CS%inputdir, default=".")
+ CS%inputdir = slasher(CS%inputdir)
+
+ allocate(CS%ind_tr(CS%ntr))
+ allocate(CS%tr_desc(CS%ntr))
+
+ allocate(CS%tr(isd:ied,jsd:jed,nz,CS%ntr), source=0.0)
+ allocate(CS%tr_source(isd:ied,jsd:jed,nz,CS%ntr), source=0.0)
+
+ do m = 1, CS%ntr
+    write(var_name(:), '(A,I3.3)') "dye", m
+    write(desc_name(:), '(A,I3.3)') "Dye Tracer ", m
+    CS%tr_desc(m) = var_desc(trim(var_name), "conc", trim(desc_name), caller=mdl)
+    tr_ptr => CS%tr(:,:,:,m)
+    call query_vardesc(CS%tr_desc(m), name=var_name, &
+         caller="register_file_dye_tracer")
+    call register_tracer(tr_ptr, tr_Reg, param_file, HI, GV, &
+         tr_desc=CS%tr_desc(m), registry_diags=.true., &
+         restart_CS=restart_CS, mandatory=.not. CS%tracers_may_reinit)
+ end do
+
+ CS%tr_Reg => tr_Reg
+ CS%restart_CSp => restart_CS
+ register_file_dye_tracer = .true.
+end function register_file_dye_tracer
+
+!> This subroutine initializes the NTR tracer fields in tr(:,:,:,:)
+! !! and it sets up the tracer output.
+subroutine initialize_file_dye_tracer(restart, day, G, GV, h, diag, OBC, CS, sponge_CSp)
+ logical, intent(in) :: restart                             !< fields already read from a restart file
+ type(time_type), target, intent(in) :: day                 !< Time of start of run
+ type(ocean_grid_type), intent(in) :: G                     !< The ocean's grid structure
+ type(verticalGrid_type), intent(in) :: GV                  !< The ocean's vertical grid structure
+ real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in) :: h !< Layer thicknesses [H ~> m or kg m-2]
+ type(diag_ctrl), target, intent(in) :: diag                !< Diagnostic control structure
+ type(ocean_OBC_type), pointer :: OBC                       !< Open boundary control structure
+ type(file_dye_tracer_CS), pointer :: CS                    !< This module's control structure
+ type(sponge_CS), pointer :: sponge_CSp                     !< Sponge control structure
+
+ integer :: m
+ character(len=32) :: name
+
+ if (.not. associated(CS)) return
+ if (CS%ntr < 1) return
+
+ CS%diag => diag
+
+ if (.not. file_exists(trim(CS%inputdir)//trim(CS%tracer_file), G%Domain)) then
+    call MOM_error(FATAL, "initial_file_dye_tracer: Unable to open " // &
+         CS%tracer_file)
+ end if
+
+ do m = 1, CS%ntr
+    call query_vardesc(CS%tr_desc(m), name, caller="initialize_file_dye_tracer")
+    call MOM_read_data(trim(CS%inputdir)//trim(CS%tracer_file), trim(name), CS%tr_source(:,:,:,m), G%Domain)
+ end do
+
+end subroutine initialize_file_dye_tracer
+
+!> This subroutine applies diapycnal diffusion and any other column
+!! tracer physics or chemistry to the tracers from this file.
+!! This is a simple example of a set of advected passive tracers.
+!! The arguments to this subroutine are redundant in that
+!!     h_new(k) = h_old(k) + ea(k) - eb(k-1) + eb(k) - ea(k+1)
+subroutine file_dye_tracer_column_physics(h_old, h_new, ea, eb, fluxes, dt, G, GV, US, CS, &
+    evap_CFL_limit, minimum_forcing_depth)
+ type(ocean_grid_type),   intent(in) :: G                     !< The ocean's grid structure
+ type(verticalGrid_type), intent(in) :: GV                    !< The ocean's vertical grid structure
+ real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                          intent(in) :: h_old                 !< Layer thickness before entrainment [H ~> m or kg m-2]
+ real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                          intent(in) :: h_new                 !< Layer thickness after entrainment [H ~> m or kg m-2]
+ real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                          intent(in) :: ea                    !< An array to which the amount of fluid entrained
+                                                              !! from the layer above during this call will be
+                                                              !! added [H ~> m or kg m-2].
+ real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), &
+                          intent(in) :: eb                    !< An array to which the amount of fluid entrained
+                                                              !! from the layer below during this call will be
+                                                              !! added [H ~> m or kg m-2].
+ type(forcing),           intent(in) :: fluxes                !< A structure with pointers to forcing fields
+ real,                    intent(in) :: dt                    !< Amount of time covered by this call [T ~> s]
+ type(unit_scale_type),   intent(in) :: US                    !< A dimensional unit scaling type
+ type(file_dye_tracer_CS), pointer :: CS                      !< This module's control structure
+ real, optional,          intent(in) :: evap_CFL_limit        !< Limit on the fraction of the water that can
+                                                              !! be fluxed out of the top layer in a timestep [nondim]
+ real, optional,          intent(in) :: minimum_forcing_depth !< The smallest depth over which
+                                                              !! fluxes can be applied [H ~> m or kg m-2]
+
+ integer :: m
+ integer :: is, ie, js, je, nz
+ real, dimension(SZI_(G),SZJ_(G),SZK_(GV)) :: h_work
+
+ is = G%isc ; ie = G%iec ; js = G%jsc ; je = G%jec ; nz = GV%ke
+
+ if (.not. associated(CS)) return
+ if (CS%ntr < 1) return
+
+ if (present(evap_CFL_limit) .and. present(minimum_forcing_depth)) then
+    do m = 1, CS%ntr
+       h_work(is:ie,js:je,1:nz) = h_old(is:ie,js:je,1:nz)
+
+       call applyTracerBoundaryFluxesInOut(G, GV, CS%tr(:,:,:,m), dt, fluxes, h_work, &
+            evap_CFL_limit, minimum_forcing_depth)
+       call tracer_vertdiff(h_work, ea, eb, dt, CS%tr(:,:,:,m), G, GV)
+    end do
+ else
+    do m = 1, CS%ntr
+       call tracer_vertdiff(h_old, ea, eb, dt, CS%tr(:,:,:,m), G, GV)
+    end do
+ end if
+
+ ! add from source every timestep
+ do m = 1, CS%ntr
+    CS%tr(is:ie,js:je,1:nz,m) = CS%tr(is:ie,js:je,1:nz,m) + CS%tr_source(is:ie,js:je,1:nz,m)
+ end do
+end subroutine file_dye_tracer_column_physics
+
+!> This subroutine extracts the surface fields from this tracer package that
+!! are to be shared with the atmosphere in coupled configurations.
+subroutine file_dye_tracer_surface_state(sfc_state, h, G, GV, CS)
+ type(ocean_grid_type), intent(in) :: G                     !< The ocean's grid structure
+ type(verticalGrid_type), intent(in) :: GV                  !< The ocean's vertical grid structure
+ type(surface), intent(inout) :: sfc_state                  !< A structure containing surface state fields
+ real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in) :: h !< Layer thickness [H ~> m or kg m-2]
+ type(file_dye_tracer_CS), pointer :: CS                    !< This module's control structure
+
+ if (.not. associated(CS)) return
+
+ ! we would potentially couple the surface to the coupler here
+end subroutine file_dye_tracer_surface_state
+
+!> This function calculates the mass-weighted integral of all tracer stocks,
+!! returning the number of stocks it has calculated.  If the stock_index
+!! is present, only the stock corresponding to that coded index is returned.
+function file_dye_stock(h, stocks, G, GV, CS, names, units, stock_index)
+ type(ocean_grid_type), intent(in) :: G                     !< The ocean's grid structure
+ type(verticalGrid_type), intent(in) :: GV                  !< The ocean's vertical grid structure
+ real, dimension(SZI_(G),SZJ_(G),SZK_(GV)), intent(in) :: h !< Layer thickness [H ~> m or kg m-2]
+ type(EFP_type), intent(out) :: stocks(:)                   !< Mass-weighted integrated amount of each
+                                                            !! tracer, in kg times concentration units [kg conc].
+ type(file_dye_tracer_CS), pointer :: CS                    !< This module's control structure
+ character(len=*), intent(out) :: names(:)                  !< The names of the stocks calculated
+ character(len=*), intent(out) :: units(:)                  !< The units of the stocks calculated
+ integer, optional, intent(in) :: stock_index               !< The number of stocks calculated here
+
+ integer :: file_dye_stock
+
+ integer :: m
+
+ file_dye_stock = 0
+ if (.not. associated(CS)) return
+ if (CS%ntr < 1) return
+
+ if (present(stock_index)) then ; if (stock_index > 0) then
+    ! check whether this stock is available...
+    return
+ end if ; end if
+
+ do m = 1, CS%ntr
+    call query_vardesc(CS%tr_desc(m), name=names(m), units=units(m), caller="file_dye_stock")
+    units(m) = trim(units(m)) // "kg"
+    stocks(m) = global_mass_int_EFP(h, G, GV, CS%tr(:,:,:,m), on_PE_only=.true.)
+ end do
+
+ file_dye_stock = CS%ntr
+end function file_dye_stock
+
+!> Deallocate memory associated with this module
+subroutine file_dyes_end(CS)
+ type(file_dye_tracer_CS), pointer :: CS !< This module's control structure
+
+ if (associated(CS)) then
+    if (associated(CS%tr)) deallocate(CS%tr)
+    deallocate(CS)
+ end if
+end subroutine file_dyes_end
+
+end module file_dye_tracer


### PR DESCRIPTION
This teaches MOM6 the "USE_FILE_DYES" option. If true, it enables a new tracer package that is similar to the dye tracer with a box source, except the source is defined from a file. The file is specified with "FILE_DYE_TRACERS_FILE", and contains "NUM_FILE_DYE_TRACERS" fields named "dyeN", where N ranges from 1 to the number of tracers. These tracers experience vertical diffusion, and are otherwise advected around as a concentration. The concentration in the source region is constantly set to 1, providing a continuous source.

(Moved from #46 for CI)