### PR TITLE
Fix accumulation of salt fluxes when `THERMO_SPANS_COUPLING`

### DIFF
--- a/config_src/drivers/FMS_cap/MOM_surface_forcing_gfdl.F90
+++ b/config_src/drivers/FMS_cap/MOM_surface_forcing_gfdl.F90
@@ -142,6 +142,8 @@ type, public :: surface_forcing_CS ; private
                                 !! to calculate gustiness.
   logical :: ustar_gustless_bug             !< If true, include a bug in the time-averaging of the
                                             !! gustless wind friction velocity.
+  logical :: excess_salt_accum_bug          !< If true, include a bug in the time-averaging of the
+                                            !! salt left in ocean at the surface from brine rejection
   logical :: check_no_land_fluxes           !< Return warning if IOB flux over land is non-zero
 
   type(diag_ctrl), pointer :: diag => NULL()  !< Structure to regulate diagnostic output timing
@@ -289,7 +291,9 @@ subroutine convert_IOB_to_fluxes(IOB, fluxes, index_bounds, Time, valid_time, G,
   ! flux type has been used.
   if (fluxes%dt_buoy_accum < 0) then
     call allocate_forcing_type(G, fluxes, water=.true., heat=.true., ustar=.not.CS%nonBous, press=.true., &
-                               fix_accum_bug=.not.CS%ustar_gustless_bug, tau_mag=CS%nonBous)
+                               fix_accum_bug=.not.CS%ustar_gustless_bug, &
+                               fix_excess_salt_accum_bug=.not.CS%excess_salt_accum_bug, &
+                               tau_mag=CS%nonBous)
 
     call safe_alloc_ptr(fluxes%sw_vis_dir,isd,ied,jsd,jed)
     call safe_alloc_ptr(fluxes%sw_vis_dif,isd,ied,jsd,jed)
@@ -1337,6 +1341,10 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, wind_stagger)
   logical :: new_sim              ! False if this simulation was started from a restart file
                                   ! or other equivalent files.
   logical :: iceberg_flux_diags   ! If true, diagnostics of fluxes from icebergs are available.
+  logical :: enable_bugs          ! If true, the defaults for certain recently added bug-fix flags are
+                                  ! set to recreate the bugs so that the code can be moved forward
+                                  ! without changing answers for existing configurations.  When this is
+                                  ! false, bugs are only used if they are actively selected.
   logical :: fix_ustar_gustless_bug  ! If false, include a bug using an older run-time parameter.
   logical :: test_value  ! This is used to determine whether a logical parameter is being set explicitly.
   logical :: explicit_bug, explicit_fix ! These indicate which parameters are set explicitly.
@@ -1681,6 +1689,11 @@ subroutine surface_forcing_init(Time, G, US, param_file, diag, CS, wind_stagger)
   call log_param(param_file, mdl, "USTAR_GUSTLESS_BUG", CS%ustar_gustless_bug, &
                  "If true include a bug in the time-averaging of the gustless wind friction velocity", &
                  default=.false.)
+  call get_param(param_file, mdl, "ENABLE_BUGS_BY_DEFAULT", enable_bugs, &
+                 default=.true., do_not_log=.true.)  ! This is logged from MOM.F90.
+  call get_param(param_file, mdl, "EXCESS_SALT_ACCUM_BUG", CS%excess_salt_accum_bug, &
+                 "If true, recover a bug in the time-averaging of the salt left in ocean at the "//&
+                 "surface from brine rejection", default=enable_bugs)
 
 
 ! See whether sufficiently thick sea ice should be treated as rigid.

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -2425,6 +2425,11 @@ subroutine fluxes_accumulate(flux_tmp, fluxes, G, wt2, forces)
 
     fluxes%salt_flux(i,j) = wt1*fluxes%salt_flux(i,j) + wt2*flux_tmp%salt_flux(i,j)
   enddo ; enddo
+  if (associated(fluxes%salt_flux_in) .and. associated(flux_tmp%salt_flux_in)) then
+    do j=js,je ; do i=is,ie
+      fluxes%salt_flux_in(i,j) = wt1*fluxes%salt_flux_in(i,j) + wt2*flux_tmp%salt_flux_in(i,j)
+    enddo ; enddo
+  endif
   if (associated(fluxes%salt_flux_added) .and. associated(flux_tmp%salt_flux_added)) then
     do j=js,je ; do i=is,ie
       fluxes%salt_flux_added(i,j) = wt1*fluxes%salt_flux_added(i,j) + wt2*flux_tmp%salt_flux_added(i,j)

--- a/src/core/MOM_forcing_type.F90
+++ b/src/core/MOM_forcing_type.F90
@@ -221,6 +221,8 @@ type, public :: forcing
                                   !! type variable has not yet been initialized.
   logical :: gustless_accum_bug = .true. !< If true, use an incorrect expression in the time
                                   !! average of the gustless wind stress.
+  logical :: excess_salt_accum_bug = .true. !< If true, use an incorrect expression in the time
+                                  !! average of salt_left_behind
   real :: C_p                   !< heat capacity of seawater [Q C-1 ~> J kg-1 degC-1].
                                 !! C_p is is the same value as in thermovar_ptrs_type.
 
@@ -2435,6 +2437,13 @@ subroutine fluxes_accumulate(flux_tmp, fluxes, G, wt2, forces)
       fluxes%salt_flux_added(i,j) = wt1*fluxes%salt_flux_added(i,j) + wt2*flux_tmp%salt_flux_added(i,j)
     enddo ; enddo
   endif
+  if (associated(fluxes%salt_left_behind) .and. associated(flux_tmp%salt_left_behind)) then
+    if (.not. fluxes%excess_salt_accum_bug) then
+      do j=js,je ; do i=is,ie
+        fluxes%salt_left_behind(i,j) = wt1*fluxes%salt_left_behind(i,j) + wt2*flux_tmp%salt_left_behind(i,j)
+      enddo ; enddo
+    endif
+  endif
   if (associated(fluxes%heat_added) .and. associated(flux_tmp%heat_added)) then
     do j=js,je ; do i=is,ie
       fluxes%heat_added(i,j) = wt1*fluxes%heat_added(i,j) + wt2*flux_tmp%heat_added(i,j)
@@ -3425,8 +3434,8 @@ end subroutine forcing_diagnostics
 
 !> Conditionally allocate fields within the forcing type
 subroutine allocate_forcing_by_group(G, fluxes, water, heat, ustar, press, &
-                                  shelf, iceberg, salt, fix_accum_bug, cfc, marbl, &
-                                  waves, shelf_sfc_accumulation, lamult, hevap, &
+                                  shelf, iceberg, salt, fix_accum_bug, fix_excess_salt_accum_bug, &
+                                  cfc, marbl, waves, shelf_sfc_accumulation, lamult, hevap, &
                                   ice_ncat, tau_mag)
   type(ocean_grid_type), intent(in) :: G       !< Ocean grid structure
   type(forcing),      intent(inout) :: fluxes  !< A structure containing thermodynamic forcing fields
@@ -3439,6 +3448,8 @@ subroutine allocate_forcing_by_group(G, fluxes, water, heat, ustar, press, &
   logical, optional,     intent(in) :: salt    !< If present and true, allocate salt fluxes
   logical, optional,     intent(in) :: fix_accum_bug !< If present and true, avoid using a bug in
                                                !! accumulation of ustar_gustless
+  logical, optional,     intent(in) :: fix_excess_salt_accum_bug !< If present and true, properly
+                                              !! accumulate salt_left_behind
   logical, optional,     intent(in) :: cfc     !< If present and true, allocate fields needed
                                                !! for cfc surface fluxes
   logical, optional,     intent(in) :: marbl   !< If present and true, allocate fields needed
@@ -3537,6 +3548,8 @@ subroutine allocate_forcing_by_group(G, fluxes, water, heat, ustar, press, &
   call myAlloc(fluxes%lamult,isd,ied,jsd,jed, lamult)
 
   if (present(fix_accum_bug)) fluxes%gustless_accum_bug = .not.fix_accum_bug
+  if (present(fix_excess_salt_accum_bug)) &
+    fluxes%excess_salt_accum_bug = .not.fix_excess_salt_accum_bug
 
   !These fields should only be allocated when USE_MARBL is activated.
   call myAlloc(fluxes%ice_fraction,isd,ied,jsd,jed, marbl)
@@ -3602,9 +3615,10 @@ subroutine allocate_forcing_by_ref(fluxes_ref, G, fluxes, turns)
   call myAlloc(fluxes%ustar_tidal, G%isd, G%ied, G%jsd, G%jed, &
       associated(fluxes_ref%ustar_tidal))
 
-  ! This flag would normally be set by a control flag in allocate_forcing_type.
+  ! These flags would normally be set by a control flag in allocate_forcing_type.
   ! Here we copy the flag from the reference forcing.
   fluxes%gustless_accum_bug = fluxes_ref%gustless_accum_bug
+  fluxes%excess_salt_accum_bug = fluxes_ref%excess_salt_accum_bug
 
   if (coupler_type_initialized(fluxes_ref%tr_fluxes)) then
     ! The data fields in the coupler_2d_bc_type are never rotated.


### PR DESCRIPTION
Fixes the accumulation of `fluxes%salt_flux_in` and `fluxes%salt_left_behind` in `fluxes_accumulate`, which is called when the thermodynamic timestep spans multiple coupling periods.

The `salt_flux_in` fix is diagnostic-only and all answers are bitwise identical.

The `salt_left_behind` fix is controlled by the new parameter `EXCESS_SALT_ACCUM_BUG` (default true); answers change only with the FMS driver when `DO_BRINE_PLUME = THERMO_SPANS_COUPLING = True` and `EXCESS_SALT_ACCUM_BUG = False`.

Closes #58 