### PR TITLE
Code updates that improve the performance of benchmark_ALE case with density-mapped diags

### DIFF
--- a/src/ALE/regrid_interp.F90
+++ b/src/ALE/regrid_interp.F90
@@ -425,7 +425,10 @@ function get_polynomial_coordinate( N, h, x_g, edge_values, ppoly_coefs, &
   ! Since discontinuous edge values are allowed, we check whether the target
   ! value lies between two discontinuous edge values at interior interfaces
   do k = 2,N
-    if ( ( target_value >= edge_values(k-1,2) ) .AND. ( target_value <= edge_values(k,1) ) ) then
+    if (target_value > edge_values(k,1) ) then
+      cycle
+    endif
+    if ( target_value >= edge_values(k-1,2) )  then
       x_tgt = x_g(k)
       return   ! return because there is no need to look further
     endif
@@ -437,7 +440,11 @@ function get_polynomial_coordinate( N, h, x_g, edge_values, ppoly_coefs, &
   ! contains the target value. The variable k_found holds the index value
   ! of the cell where the taregt value lies.
   do k = 1,N
-    if ( ( target_value > edge_values(k,1) ) .AND. ( target_value < edge_values(k,2) ) ) then
+    if ( target_value >= edge_values(k,2) ) then
+      cycle
+    endif
+
+    if ( target_value > edge_values(k,1) ) then
       k_found = k
       exit
     endif

--- a/src/ALE/regrid_interp.F90
+++ b/src/ALE/regrid_interp.F90
@@ -414,6 +414,14 @@ function get_polynomial_coordinate( N, h, x_g, edge_values, ppoly_coefs, &
     return  ! return because there is no need to look further
   endif
 
+  ! If the target value is outside the range of all values, we
+  ! force the target coordinate to be equal to the lowest or
+  ! largest value, depending on which bound is overtaken
+  if ( target_value >= edge_values(N,2) ) then
+    x_tgt = x_g(N+1)
+    return  ! return because there is no need to look further
+  endif
+
   ! Since discontinuous edge values are allowed, we check whether the target
   ! value lies between two discontinuous edge values at interior interfaces
   do k = 2,N
@@ -422,14 +430,6 @@ function get_polynomial_coordinate( N, h, x_g, edge_values, ppoly_coefs, &
       return   ! return because there is no need to look further
     endif
   enddo
-
-  ! If the target value is outside the range of all values, we
-  ! force the target coordinate to be equal to the lowest or
-  ! largest value, depending on which bound is overtaken
-  if ( target_value >= edge_values(N,2) ) then
-    x_tgt = x_g(N+1)
-    return  ! return because there is no need to look further
-  endif
 
   ! At this point, we know that the target value is bounded and does not
   ! lie between discontinuous, monotonic edge values. Therefore,

--- a/src/ALE/regrid_interp.F90
+++ b/src/ALE/regrid_interp.F90
@@ -375,6 +375,7 @@ end subroutine build_and_interpolate_grid
 !!
 !! It is assumed that the number of cells defining 'grid' and 'ppoly' are the
 !! same.
+!DIR$ ATTRIBUTES FORCEINLINE :: get_polynomial_coordinate
 function get_polynomial_coordinate( N, h, x_g, edge_values, ppoly_coefs, &
                                     target_value, degree, answer_date ) result ( x_tgt )
   ! Arguments

--- a/src/ALE/regrid_interp.F90
+++ b/src/ALE/regrid_interp.F90
@@ -401,6 +401,7 @@ function get_polynomial_coordinate( N, h, x_g, edge_values, ppoly_coefs, &
   integer :: k_found     ! index of target cell
   character(len=320) :: mesg
   logical :: use_2018_answers  ! If true use older, less accurate expressions.
+  integer :: maybe_kfound ! temporary variable to store a potential k_found value
 
   eps = NR_OFFSET
   k_found = -1
@@ -424,8 +425,10 @@ function get_polynomial_coordinate( N, h, x_g, edge_values, ppoly_coefs, &
 
   ! Since discontinuous edge values are allowed, we check whether the target
   ! value lies between two discontinuous edge values at interior interfaces
+  maybe_kfound = -1
   do k = 2,N
     if (target_value > edge_values(k,1) ) then
+      maybe_kfound = k
       cycle
     endif
     if ( target_value >= edge_values(k-1,2) )  then
@@ -439,17 +442,20 @@ function get_polynomial_coordinate( N, h, x_g, edge_values, ppoly_coefs, &
   ! there is a unique solution. We loop on all cells and find which one
   ! contains the target value. The variable k_found holds the index value
   ! of the cell where the taregt value lies.
-  do k = 1,N
-    if ( target_value >= edge_values(k,2) ) then
-      cycle
-    endif
+  if ((maybe_kfound /= -1) .AND. (target_value < edge_values(maybe_kfound,2))) then
+    k_found = maybe_kfound
+  else
+    do k = 1,N
+      if ( target_value >= edge_values(k,2) ) then
+        cycle
+      endif
 
-    if ( target_value > edge_values(k,1) ) then
-      k_found = k
-      exit
-    endif
-  enddo
-
+      if ( target_value > edge_values(k,1) ) then
+        k_found = k
+        exit
+      endif
+    enddo
+  endif
   ! At this point, 'k_found' should be strictly positive. If not, this is
   ! a major failure because it means we could not find any target cell
   ! despite the fact that the target value lies between the extremes. It

--- a/src/equation_of_state/MOM_EOS_Roquet_rho.F90
+++ b/src/equation_of_state/MOM_EOS_Roquet_rho.F90
@@ -183,6 +183,8 @@ contains
   procedure :: calculate_density_array => calculate_density_array_Roquet_rho
   !> Local implementation of generic calculate_spec_vol_array for efficiency
   procedure :: calculate_spec_vol_array => calculate_spec_vol_array_Roquet_rho
+  !> Local implementation of generic calculate_density_derivs_array for efficiency
+  procedure :: calculate_density_derivs_array => calculate_density_derivs_array_Roquet_rho
 
 end type Roquet_rho_EOS
 
@@ -676,6 +678,31 @@ subroutine calculate_spec_vol_array_Roquet_rho(this, T, S, pressure, specvol, st
   endif
 
 end subroutine calculate_spec_vol_array_Roquet_rho
+
+!> Calculate the density derivatives for 1D array inputs and outputs.
+subroutine calculate_density_derivs_array_Roquet_rho(this, T, S, pressure, drho_dT, drho_dS, start, npts)
+  class(Roquet_rho_EOS),    intent(in)  :: this     !< This EOS
+  real, dimension(:), intent(in)  :: T        !< Potential temperature relative to the surface [degC]
+  real, dimension(:), intent(in)  :: S        !< Salinity [PSU]
+  real, dimension(:), intent(in)  :: pressure !< Pressure [Pa]
+  real, dimension(:), intent(out) :: drho_dT  !< The partial derivative of density with potential
+                                              !! temperature [kg m-3 degC-1]
+  real, dimension(:), intent(out) :: drho_dS  !< The partial derivative of density with salinity,
+                                              !! in [kg m-3 PSU-1]
+  integer,            intent(in)  :: start    !< The starting index for calculations
+  integer,            intent(in)  :: npts     !< The number of values to calculate  ! Local variables
+
+  ! Local variables
+  integer :: js, je
+
+  js = start
+  je = start+npts-1
+
+  call calculate_density_derivs_elem_Roquet_rho(this, T(js:je), S(js:je), pressure(js:je), &
+                                                drho_dt(js:je), drho_ds(js:je))
+
+end subroutine calculate_density_derivs_array_Roquet_rho
+
 
 !> \namespace mom_eos_Roquet_rho
 !!

--- a/src/equation_of_state/MOM_EOS_Roquet_rho.F90
+++ b/src/equation_of_state/MOM_EOS_Roquet_rho.F90
@@ -530,11 +530,13 @@ elemental subroutine calculate_specvol_derivs_elem_Roquet_rho(this, T, S, pressu
   real :: rho     ! In situ density [kg m-3]
   real :: dRho_dT ! Derivative of density with temperature [kg m-3 degC-1]
   real :: dRho_dS ! Derivative of density with salinity [kg m-3 ppt-1]
+  real :: inv_rhosqr ! The inverse of the square of density [m6 kg-2]
 
   call calculate_density_derivs_elem_Roquet_rho(this, T, S, pressure, dRho_dT, dRho_dS)
   rho = density_elem_Roquet_rho(this, T, S, pressure)
-  dSV_dT = -dRho_DT/(rho**2)
-  dSV_dS = -dRho_DS/(rho**2)
+  inv_rhosqr = 1.0 / (rho*rho)
+  dSV_dT = -dRho_DT * inv_rhosqr
+  dSV_dS = -dRho_DS * inv_rhosqr
 
 end subroutine calculate_specvol_derivs_elem_Roquet_rho
 

--- a/src/equation_of_state/MOM_EOS_Roquet_rho.F90
+++ b/src/equation_of_state/MOM_EOS_Roquet_rho.F90
@@ -191,6 +191,7 @@ contains
 !> In situ density of sea water from Roquet et al., 2015 [kg m-3]
 !!
 !! This is an elemental function that can be applied to any combination of scalar and array inputs.
+!DIR$ ATTRIBUTES FORCEINLINE :: density_elem_Roquet_rho
 real elemental function density_elem_Roquet_rho(this, T, S, pressure)
   class(Roquet_rho_EOS), intent(in) :: this     !< This EOS
   real,                  intent(in) :: T        !< Conservative temperature [degC]
@@ -250,6 +251,7 @@ end function density_elem_Roquet_rho
 !> In situ density anomaly of sea water from Roquet et al., 2015 [kg m-3]
 !!
 !! This is an elemental function that can be applied to any combination of scalar and array inputs.
+!DIR$ ATTRIBUTES FORCEINLINE :: density_anomaly_elem_Roquet_rho
 real elemental function density_anomaly_elem_Roquet_rho(this, T, S, pressure, rho_ref)
   class(Roquet_rho_EOS), intent(in) :: this     !< This EOS
   real,                  intent(in) :: T        !< Conservative temperature [degC]
@@ -312,6 +314,7 @@ end function density_anomaly_elem_Roquet_rho
 !> In situ specific volume of sea water from Roquet et al., 2015 [kg m-3]
 !!
 !! This is an elemental function that can be applied to any combination of scalar and array inputs.
+!DIR$ ATTRIBUTES FORCEINLINE :: spec_vol_elem_Roquet_rho
 real elemental function spec_vol_elem_Roquet_rho(this, T, S, pressure)
   class(Roquet_rho_EOS), intent(in) :: this     !< This EOS
   real,                  intent(in) :: T        !< Conservative temperature [degC]
@@ -325,6 +328,7 @@ end function spec_vol_elem_Roquet_rho
 !> In situ specific volume anomaly of sea water from Roquet et al., 2015 [kg m-3]
 !!
 !! This is an elemental function that can be applied to any combination of scalar and array inputs.
+!DIR$ ATTRIBUTES FORCEINLINE :: spec_vol_anomaly_elem_Roquet_rho
 real elemental function spec_vol_anomaly_elem_Roquet_rho(this, T, S, pressure, spv_ref)
   class(Roquet_rho_EOS), intent(in) :: this     !< This EOS
   real,                  intent(in) :: T        !< Conservative temperature [degC]
@@ -339,6 +343,7 @@ end function spec_vol_anomaly_elem_Roquet_rho
 
 !> For a given thermodynamic state, calculate the derivatives of density with conservative
 !! temperature and absolute salinity, using the density polynomial fit EOS from Roquet et al. (2015).
+!DIR$ ATTRIBUTES FORCEINLINE :: calculate_density_derivs_elem_Roquet_rho
 elemental subroutine calculate_density_derivs_elem_Roquet_rho(this, T, S, pressure, drho_dT, drho_dS)
   class(Roquet_rho_EOS), intent(in)  :: this     !< This EOS
   real,                  intent(in)  :: T        !< Conservative temperature [degC]
@@ -413,6 +418,7 @@ elemental subroutine calculate_density_derivs_elem_Roquet_rho(this, T, S, pressu
 end subroutine calculate_density_derivs_elem_Roquet_rho
 
 !> Second derivatives of density with respect to temperature, salinity, and pressure
+!DIR$ ATTRIBUTES FORCEINLINE :: calculate_density_second_derivs_elem_Roquet_rho
 elemental subroutine calculate_density_second_derivs_elem_Roquet_rho(this, T, S, pressure, &
                        drho_ds_ds, drho_ds_dt, drho_dt_dt, drho_ds_dp, drho_dt_dp)
   class(Roquet_rho_EOS), intent(in) :: this !< This EOS
@@ -506,6 +512,7 @@ end subroutine calculate_density_second_derivs_elem_Roquet_rho
 
 !> Calculate the partial derivatives of specific volume with temperature and salinity
 !! using the density polynomial fit EOS from Roquet et al. (2015).
+!DIR$ ATTRIBUTES FORCEINLINE :: calculate_specvol_derivs_elem_Roquet_rho
 elemental subroutine calculate_specvol_derivs_elem_Roquet_rho(this, T, S, pressure, dSV_dT, dSV_dS)
   class(Roquet_rho_EOS), intent(in)    :: this     !< This EOS
   real,                  intent(in)    :: T        !< Conservative temperature [degC]
@@ -531,6 +538,7 @@ end subroutine calculate_specvol_derivs_elem_Roquet_rho
 !! (drho/dp = C_sound^-2, stored as drho_dp [s2 m-2]) from absolute salinity (sal [g kg-1]),
 !! conservative temperature (T [degC]), and pressure [Pa], using the density polynomial
 !! fit EOS from Roquet et al. (2015).
+!DIR$ ATTRIBUTES FORCEINLINE :: calculate_compress_elem_Roquet_rho
 elemental subroutine calculate_compress_elem_Roquet_rho(this, T, S, pressure, rho, drho_dp)
   class(Roquet_rho_EOS), intent(in)  :: this !< This EOS
   real,                  intent(in)  :: T        !< Conservative temperature [degC]

--- a/src/equation_of_state/MOM_EOS_Roquet_rho.F90
+++ b/src/equation_of_state/MOM_EOS_Roquet_rho.F90
@@ -531,8 +531,8 @@ elemental subroutine calculate_specvol_derivs_elem_Roquet_rho(this, T, S, pressu
   real :: dRho_dT ! Derivative of density with temperature [kg m-3 degC-1]
   real :: dRho_dS ! Derivative of density with salinity [kg m-3 ppt-1]
 
-  call this%calculate_density_derivs_elem(T, S, pressure, drho_dT, drho_dS)
-  rho = this%density_elem(T, S, pressure)
+  call calculate_density_derivs_elem_Roquet_rho(this, T, S, pressure, dRho_dT, dRho_dS)
+  rho = density_elem_Roquet_rho(this, T, S, pressure)
   dSV_dT = -dRho_DT/(rho**2)
   dSV_dS = -dRho_DS/(rho**2)
 

--- a/src/equation_of_state/MOM_EOS_Roquet_rho.F90
+++ b/src/equation_of_state/MOM_EOS_Roquet_rho.F90
@@ -535,8 +535,8 @@ elemental subroutine calculate_specvol_derivs_elem_Roquet_rho(this, T, S, pressu
   call calculate_density_derivs_elem_Roquet_rho(this, T, S, pressure, dRho_dT, dRho_dS)
   rho = density_elem_Roquet_rho(this, T, S, pressure)
   inv_rhosqr = 1.0 / (rho*rho)
-  dSV_dT = -dRho_DT * inv_rhosqr
-  dSV_dS = -dRho_DS * inv_rhosqr
+  dSV_dT = -dRho_dT * inv_rhosqr
+  dSV_dS = -dRho_dS * inv_rhosqr
 
 end subroutine calculate_specvol_derivs_elem_Roquet_rho
 

--- a/src/equation_of_state/MOM_EOS_Roquet_rho.F90
+++ b/src/equation_of_state/MOM_EOS_Roquet_rho.F90
@@ -185,6 +185,8 @@ contains
   procedure :: calculate_spec_vol_array => calculate_spec_vol_array_Roquet_rho
   !> Local implementation of generic calculate_density_derivs_array for efficiency
   procedure :: calculate_density_derivs_array => calculate_density_derivs_array_Roquet_rho
+  !> Local implementation of generic calculate_specvol_derivs_array for efficiency
+  procedure :: calculate_specvol_derivs_array => calculate_specvol_derivs_array_Roquet_rho
 
 end type Roquet_rho_EOS
 
@@ -535,6 +537,30 @@ elemental subroutine calculate_specvol_derivs_elem_Roquet_rho(this, T, S, pressu
   dSV_dS = -dRho_DS/(rho**2)
 
 end subroutine calculate_specvol_derivs_elem_Roquet_rho
+
+
+subroutine calculate_specvol_derivs_array_Roquet_rho(this, T, S, pressure, dSV_dT, dSV_dS, start, npts)
+  class(Roquet_rho_EOS), intent(in) :: this     !< This EOS
+  real, dimension(:), intent(in)    :: T        !< Potential temperature [degC]
+  real, dimension(:), intent(in)    :: S        !< Salinity [PSU]
+  real, dimension(:), intent(in)    :: pressure !< Pressure [Pa]
+  real, dimension(:), intent(inout) :: dSV_dT   !< The partial derivative of specific volume with
+                                                !! potential temperature [m3 kg-1 degC-1]
+  real, dimension(:), intent(inout) :: dSV_dS   !< The partial derivative of specific volume with
+                                                !! salinity [m3 kg-1 PSU-1]
+  integer,            intent(in)    :: start    !< The starting index for calculations
+  integer,            intent(in)    :: npts     !< The number of values to calculate
+
+  ! Local variables
+  integer :: js, je
+
+  js = start
+  je = start+npts-1
+
+  call calculate_specvol_derivs_elem_Roquet_rho(this, T(js:je), S(js:je), pressure(js:je), &
+                                                dSV_dT(js:je), dSV_dS(js:je))
+
+end subroutine calculate_specvol_derivs_array_Roquet_rho
 
 !> Compute the in situ density of sea water (rho in [kg m-3]) and the compressibility
 !! (drho/dp = C_sound^-2, stored as drho_dp [s2 m-2]) from absolute salinity (sal [g kg-1]),


### PR DESCRIPTION
Fix for #47 

The base case was [benchmark_ALE](https://github.com/marshallward/mom6-benchmark/tree/main/benchmark_ALE) with the following patch (patch generated with `git diff --patch MOM_input diag_table`):

```patch
diff --git a/benchmark_ALE/MOM_input b/benchmark_ALE/MOM_input
index b52b28e..39fbc55 100644
--- a/benchmark_ALE/MOM_input
+++ b/benchmark_ALE/MOM_input
@@ -184,6 +184,14 @@ INITIAL_T_RANGE = -9.0          !   [degC] default = 0.0
                                 ! Initial temperature range (bottom - surface)
 
 ! === module MOM_diag_mediator ===
+NUM_DIAG_COORDS = 1
+DIAG_COORDS = "rho2 RHO2 RHO" !"z Z ZSTAR" !
+DIAG_COORD_DEF_RHO2 = "RFNC1:76,999.5,1020.,1034.1,3.1,1041.,0.002" ! default = "WOA09"
+REGRIDDING_ANSWER_DATE = 99991231 ! default = 20181231
 
 ! === module MOM_MEKE ===
 USE_MEKE = True                 !   [Boolean] default = False
diff --git a/benchmark_ALE/diag_table b/benchmark_ALE/diag_table
index 42b4a98..02ceeb8 100644
--- a/benchmark_ALE/diag_table
+++ b/benchmark_ALE/diag_table
@@ -47,6 +47,10 @@ benchmark_ALE
  "ocean_model",   "zos",        "zos",          "ocean_month", "all", "mean", "none",2
  "ocean_model",   "Rd1",        "Rd1",          "ocean_month", "all", "mean", "none",2
 
+# monthly 3d fields on rho2
+"access-om3.mom6.3d.umo+rho2.1mon.mean.%4yr", 1, "months", 1, "days", "time", 1, "years"
+"ocean_model_rho2", "umo", "umo", "access-om3.mom6.3d.umo+rho2.1mon.mean.%4yr", "all", "average", "none", 2
+
 # 3d annual
  "ocean_model_z", "agessc",     "agessc",       "ocean_annual_z", "all", "mean", "none",2

```

The baseline `benchmark_ALE` runtime improves from 145s (possibly longer since I had forgotten to compile with `-fp-model=precise` for the baseline) to 98s for a version that contained all of these changes (and some more that made minor performance impact) - about a 30% improvement in runtime.  Most of the improvement comes from inlining `density_anomaly_elem_Roquet_rho` (~22s) and the extrapolation check reordering in `get_polynomial_coordinate` (~12s). The changes for the EOS are currently confined to the Roquet but would (should?) be carried across to the other EOS'.

From my tests with the [deployments](https://github.com/ACCESS-NRI/ACCESS-OM3/pull/236), the OM3 25k IAF runtime improves by about 10% (but that's probably because the load-balancing is now off)

I will add in performance tables here, once I have them in a easily-parseable format